### PR TITLE
Add Google Analytics integration with tracking ID G-223ZBY1BM9

### DIFF
--- a/lib/gtag.js
+++ b/lib/gtag.js
@@ -1,0 +1,22 @@
+// Google Analytics configuration
+export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID || 'G-223ZBY1BM9'
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url) => {
+  if (typeof window !== 'undefined') {
+    window.gtag('config', GA_TRACKING_ID, {
+      page_location: url,
+    })
+  }
+}
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }) => {
+  if (typeof window !== 'undefined') {
+    window.gtag('event', action, {
+      event_category: category,
+      event_label: label,
+      value: value,
+    })
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,22 @@
-
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { pageview } from '../lib/gtag'
 import '../styles/globals.css'
 
-export default function App({ Component, pageProps }) {
+function MyApp({ Component, pageProps }) {
+  const router = useRouter()
+
+  useEffect(() => {
+    const handleRouteChange = (url) => {
+      pageview(url)
+    }
+    router.events.on('routeChangeComplete', handleRouteChange)
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange)
+    }
+  }, [router.events])
+
   return <Component {...pageProps} />
 }
+
+export default MyApp

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,33 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+import { GA_TRACKING_ID } from '../lib/gtag'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        {/* Global Site Tag (gtag.js) - Google Analytics */}
+        <script
+          async
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+        />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_TRACKING_ID}', {
+              page_location: window.location.href,
+              page_title: document.title,
+            });
+          `,
+          }}
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}


### PR DESCRIPTION
- Implement Google Analytics 4 tracking
- Add page view and event tracking capabilities
- Configure environment variables for GA ID
- Add analytics integration to _app.js and _document.js
- Set up gtag configuration for AuditsReady website analytics