### PR TITLE
Fix contact form: Replace mailto with Resend API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Resend API Key for sending emails
+# Get your API key from: https://resend.com/api-keys
+RESEND_API_KEY=re_your_api_key_here
+
+# Google Analytics
+NEXT_PUBLIC_GA_ID=G-223ZBY1BM9

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -1,0 +1,65 @@
+export default async function handler(req, res) {
+  // Only allow POST requests
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const { name, company, email, phone, message } = req.body;
+
+  // Basic validation
+  if (!name || !company || !email || !message) {
+    return res.status(400).json({ message: 'Missing required fields' });
+  }
+
+  try {
+    // Using Resend API for email sending
+    // Note: You'll need to set RESEND_API_KEY environment variable in Vercel
+    const emailContent = `
+New AI Demo Request from AuditsReady Website
+
+Name: ${name}
+Company: ${company}
+Email: ${email}
+Phone: ${phone || 'Not provided'}
+
+Message:
+${message}
+
+---
+Note: Customer expects a call within 24 hours.
+Submitted: ${new Date().toLocaleString()}
+    `;
+
+    // Send email using fetch to Resend API
+    const resendResponse = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.RESEND_API_KEY}`
+      },
+      body: JSON.stringify({
+        from: 'AuditsReady Contact Form <onboarding@resend.dev>',
+        to: 'info@auditsready.com',
+        subject: `AI Demo Request from ${name} - ${company}`,
+        text: emailContent,
+        reply_to: email
+      })
+    });
+
+    if (!resendResponse.ok) {
+      throw new Error('Failed to send email');
+    }
+
+    return res.status(200).json({
+      success: true,
+      message: 'Request submitted successfully!'
+    });
+
+  } catch (error) {
+    console.error('Error sending email:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to send request. Please try again or email us directly at info@auditsready.com'
+    });
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -66,29 +66,32 @@ function ContactFormModal({ isOpen, onClose }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setIsSubmitting(true);
+    setSubmitStatus(null);
 
     try {
-      // Create mailto link with form data
-      const subject = encodeURIComponent('AI Demo Request from ' + formData.name);
-      const body = encodeURIComponent(`
-Name: ${formData.name}
-Company: ${formData.company}
-Email: ${formData.email}
-Phone: ${formData.phone}
-Message: ${formData.message}
+      // Send form data to API endpoint
+      const response = await fetch('/api/contact', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formData)
+      });
 
-Note: Customer expects a call within 24 hours.
-      `);
+      const data = await response.json();
 
-      window.location.href = `mailto:info@auditsready.com?subject=${subject}&body=${body}`;
-
-      setSubmitStatus('success');
-      setTimeout(() => {
-        onClose();
-        setFormData({ name: '', company: '', email: '', phone: '', message: '' });
-        setSubmitStatus(null);
-      }, 2000);
+      if (response.ok) {
+        setSubmitStatus('success');
+        setTimeout(() => {
+          onClose();
+          setFormData({ name: '', company: '', email: '', phone: '', message: '' });
+          setSubmitStatus(null);
+        }, 3000);
+      } else {
+        setSubmitStatus('error');
+      }
     } catch (error) {
+      console.error('Form submission error:', error);
       setSubmitStatus('error');
     } finally {
       setIsSubmitting(false);
@@ -195,13 +198,15 @@ Note: Customer expects a call within 24 hours.
 
             {submitStatus === 'success' && (
               <div className="mt-4 bg-green-50 border border-green-200 rounded-lg p-4">
-                <p className="text-green-800">Thank you! Opening your email client...</p>
+                <p className="text-green-800 font-semibold">✓ Thank you! Your request has been submitted successfully.</p>
+                <p className="text-green-700 text-sm mt-1">We'll call you within 24 hours to schedule your demo.</p>
               </div>
             )}
 
             {submitStatus === 'error' && (
               <div className="mt-4 bg-red-50 border border-red-200 rounded-lg p-4">
-                <p className="text-red-800">Something went wrong. Please try again.</p>
+                <p className="text-red-800 font-semibold">Something went wrong. Please try again.</p>
+                <p className="text-red-700 text-sm mt-1">Or email us directly at info@auditsready.com</p>
               </div>
             )}
 


### PR DESCRIPTION
## Summary
Replace unreliable mailto link with proper Resend API for professional email delivery from contact form.

## Problem with mailto
- ❌ Requires user to have email client configured
- ❌ User can see it's just opening their email app
- ❌ No confirmation if email was actually sent
- ❌ Unprofessional user experience

## Solution: Resend API ✅
- ✅ Direct API submission (no email client needed)
- ✅ Professional email formatting
- ✅ Reliable delivery confirmation
- ✅ Reply-to set to customer's email
- ✅ Proper error handling with fallback message

## Technical Implementation
- Created `/api/contact` endpoint for form submissions
- Using Resend API (free tier: 100 emails/day, 3,000/month)
- Emails sent from `onboarding@resend.dev` (Resend test domain)
- Delivered to `info@auditsready.com`
- ImprovMX forwards to personal email

## Files Changed
- `pages/api/contact.js` - New API endpoint
- `pages/index.js` - Updated form submission logic
- `.env.example` - Documentation for required env vars

## Setup Required (Vercel)
Add environment variable in Vercel Dashboard:
- Variable: `RESEND_API_KEY`
- Value: `re_7R9j7PVX_GR8WzoKs9L5phAaCAAyrVFjQ`

## Email Flow
```
Customer Form → /api/contact → Resend API → info@auditsready.com → ImprovMX → Your Email
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)