### PR TITLE
Fix: Improve error logging in contact form API

### DIFF
--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -46,9 +46,22 @@ Submitted: ${new Date().toLocaleString()}
       })
     });
 
+    // Parse the response to get detailed error info
+    const resendData = await resendResponse.json();
+
     if (!resendResponse.ok) {
-      throw new Error('Failed to send email');
+      // Log detailed error for debugging
+      console.error('Resend API Error Details:', {
+        status: resendResponse.status,
+        statusText: resendResponse.statusText,
+        errorData: resendData,
+        hasApiKey: !!process.env.RESEND_API_KEY
+      });
+
+      throw new Error(`Resend API error: ${JSON.stringify(resendData)}`);
     }
+
+    console.log('Email sent successfully via Resend:', resendData.id);
 
     return res.status(200).json({
       success: true,


### PR DESCRIPTION
## Changes
- Added detailed error logging to capture Resend API error responses
- Parse JSON response before checking status to see actual error details
- Log success message with email ID when sending works

## Why
Currently getting 500 errors from contact form but can't see the actual Resend API error. This will help diagnose the root cause.

## Testing
After merge, test the contact form and check Vercel logs for detailed error information.