### PR TITLE
Use verified auditsready.com domain for contact form

### DIFF
--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -38,7 +38,7 @@ Submitted: ${new Date().toLocaleString()}
         'Authorization': `Bearer ${process.env.RESEND_API_KEY}`
       },
       body: JSON.stringify({
-        from: 'AuditsReady Contact Form <onboarding@resend.dev>',
+        from: 'AuditsReady Contact Form <noreply@auditsready.com>',
         to: 'info@auditsready.com',
         subject: `AI Demo Request from ${name} - ${company}`,
         text: emailContent,


### PR DESCRIPTION
## Changes
- Changed sender email from `onboarding@resend.dev` to `noreply@auditsready.com`
- Now using verified auditsready.com domain in Resend

## Why
- auditsready.com domain is now verified in Resend (DKIM, SPF, DMARC)
- More professional sender address
- Better email deliverability
- No restrictions on recipient addresses

## Email Flow
```
Customer submits form
  ↓
Resend sends FROM: noreply@auditsready.com
  ↓
TO: info@auditsready.com
  ↓
ImprovMX forwards to personal email
```

## Testing
After merge, test the contact form and verify email is received.