### PR TITLE
Fix Gmail phishing warning on contact form emails

### DIFF
--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -41,8 +41,7 @@ Submitted: ${new Date().toLocaleString()}
         from: 'AuditsReady Contact Form <noreply@auditsready.com>',
         to: 'info@auditsready.com',
         subject: `AI Demo Request from ${name} - ${company}`,
-        text: emailContent,
-        reply_to: email
+        text: emailContent
       })
     });
 


### PR DESCRIPTION
## Problem
Gmail was showing a phishing warning on contact form emails: "This message appears to be from auditsready.com, but replies go to another email address"

This happened because the `reply_to` header was set to the customer's email address, creating a mismatch with the `from` address.

## Solution
Removed the `reply_to` field from the Resend API call in `/pages/api/contact.js`

## Impact
- ✅ Eliminates Gmail phishing warning
- ✅ Customer email still clearly visible in email body
- ✅ Recipient can click email address to reply manually
- ✅ Standard practice for contact forms

## Testing
Test by submitting the contact form and checking that:
1. Email arrives without phishing warning
2. Customer email is clickable in the body
3. All form data is intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)