### PR TITLE
Improve internal linking on 3 weakest blog posts

### DIFF
--- a/pages/blog/how-long-does-iso-9001-take.js
+++ b/pages/blog/how-long-does-iso-9001-take.js
@@ -557,6 +557,17 @@ export default function HowLongISO9001Post() {
               </Link>
             </div>
 
+            <div className="bg-gray-50 rounded-xl p-6 mb-8 border border-gray-200">
+              <h3 className="text-lg font-bold text-gray-900 mb-4">More Helpful Guides</h3>
+              <ul className="space-y-2">
+                <li><Link href="/blog/how-to-prepare-for-iso-9001-audit" className="text-blue-700 hover:underline">How to Prepare for Your ISO 9001 Certification Audit</Link></li>
+                <li><Link href="/blog/iso-9001-gap-analysis-cost" className="text-blue-700 hover:underline">ISO 9001 Gap Analysis Cost: Complete Breakdown</Link></li>
+                <li><Link href="/blog/iso-9001-document-control" className="text-blue-700 hover:underline">ISO 9001 Document Control: Complete Guide (2026)</Link></li>
+                <li><Link href="/blog/iso-9001-internal-audit-guide" className="text-blue-700 hover:underline">ISO 9001 Internal Audit Guide: How to Conduct Effective Audits</Link></li>
+                <li><Link href="/blog/iso-9001-requirements" className="text-blue-700 hover:underline">ISO 9001 Requirements: Complete Guide to All 10 Clauses</Link></li>
+              </ul>
+            </div>
+
             <div className="flex justify-between items-center">
               <Link
                 href="/blog"

--- a/pages/blog/how-to-prepare-for-iso-9001-audit.js
+++ b/pages/blog/how-to-prepare-for-iso-9001-audit.js
@@ -675,8 +675,20 @@ export default function AuditPreparationPost() {
             </p>
           </div>
 
+          {/* Related Reading */}
+          <div className="bg-gray-50 rounded-xl p-6 mb-8 border border-gray-200 mt-12">
+            <h3 className="text-lg font-bold text-gray-900 mb-4">Related Reading</h3>
+            <ul className="space-y-2">
+              <li><Link href="/blog/iso-9001-internal-audit-guide" className="text-blue-700 hover:underline">ISO 9001 Internal Audit Guide: How to Conduct Effective Audits</Link></li>
+              <li><Link href="/blog/iso-9001-document-control" className="text-blue-700 hover:underline">ISO 9001 Document Control: Complete Guide (2026)</Link></li>
+              <li><Link href="/blog/failed-iso-9001-audit" className="text-blue-700 hover:underline">What Happens If You Fail Your ISO 9001 Audit?</Link></li>
+              <li><Link href="/blog/iso-9001-gap-analysis-cost" className="text-blue-700 hover:underline">ISO 9001 Gap Analysis Cost: Complete Breakdown</Link></li>
+              <li><Link href="/blog/iso-9001-requirements" className="text-blue-700 hover:underline">ISO 9001 Requirements: Complete Guide to All 10 Clauses</Link></li>
+            </ul>
+          </div>
+
           {/* Bottom Navigation */}
-          <div className="mt-12 pt-8 border-t-2 border-gray-200 flex justify-between items-center">
+          <div className="pt-8 border-t-2 border-gray-200 flex justify-between items-center">
             <Link
               href="/blog"
               className="text-blue-600 hover:text-blue-800 font-semibold flex items-center gap-2 transition-colors"

--- a/pages/blog/iso-9001-gap-analysis-cost.js
+++ b/pages/blog/iso-9001-gap-analysis-cost.js
@@ -483,8 +483,20 @@ export default function GapAnalysisCostPost() {
             </p>
           </div>
 
+          {/* Related Reading */}
+          <div className="bg-gray-50 rounded-xl p-6 mb-8 border border-gray-200 mt-12">
+            <h3 className="text-lg font-bold text-gray-900 mb-4">Related Reading</h3>
+            <ul className="space-y-2">
+              <li><Link href="/blog/iso-9001-certification-cost" className="text-blue-700 hover:underline">ISO 9001 Certification Cost: Complete Breakdown ($50k-$150k+)</Link></li>
+              <li><Link href="/blog/iso-9001-requirements" className="text-blue-700 hover:underline">ISO 9001 Requirements: Complete Guide to All 10 Clauses</Link></li>
+              <li><Link href="/blog/iso-9001-consultant-vs-ai" className="text-blue-700 hover:underline">Traditional ISO Consultants vs. AI: Honest Comparison</Link></li>
+              <li><Link href="/blog/how-long-does-iso-9001-take" className="text-blue-700 hover:underline">How Long Does ISO 9001 Certification Take?</Link></li>
+              <li><Link href="/blog/iso-9001-document-control" className="text-blue-700 hover:underline">ISO 9001 Document Control: Complete Guide (2026)</Link></li>
+            </ul>
+          </div>
+
           {/* Bottom Navigation */}
-          <div className="mt-12 pt-8 border-t-2 border-gray-200 flex justify-between items-center">
+          <div className="pt-8 border-t-2 border-gray-200 flex justify-between items-center">
             <Link
               href="/blog"
               className="text-blue-600 hover:text-blue-800 font-semibold flex items-center gap-2 transition-colors"


### PR DESCRIPTION
## Summary
- Added 5 internal links each to the 3 posts with weakest internal linking
- `iso-9001-gap-analysis-cost` had **0 links** (orphan page) → now 5
- `how-to-prepare-for-iso-9001-audit` had **2 links** → now 7
- `how-long-does-iso-9001-take` had **2 links** → now 7

## SEO Impact
- Fixes orphan page issue (Google devalues pages with no internal links)
- Strengthens topical cluster around hub post (iso-9001-requirements)
- All 3 posts now link to the new document-control post (cross-pollination)
- Expected: improved crawl discovery and ranking signals within 2-4 weeks

## Test plan
- [x] `next build` passes
- [ ] Verify links render on preview deployment

Generated with [Claude Code](https://claude.com/claude-code)