### PR TITLE
Reposition site: industrial-manufacturing beachhead, P.Eng-led, demote AI

### DIFF
--- a/BUSINESS_MODEL.md
+++ b/BUSINESS_MODEL.md
@@ -1,0 +1,105 @@
+# AuditsReady — Business Model
+
+> **Status:** Working model as of 2026-07-05, written alongside the industrial-manufacturing repositioning (branch `reposition-manufacturing`). This documents *how the money is meant to work* so the pricing on the site has a rationale behind it.
+>
+> **Read this honestly:** items marked **[Established]** are grounded in the repo (CLAUDE.md, page copy, the pre-assessment checklist PDF). Items marked **[Assumption]** are unvalidated bets — no case studies or conversion data exist yet. Do not treat assumptions as facts.
+
+---
+
+## 1. What we sell
+
+**[Established]** A **productized consulting service**, not a software product:
+
+- A licensed Professional Engineer (P.Eng, APEGA) reviews a manufacturer's quality documentation against ISO 9001:2015 and returns a findings report: what's missing, mapped to specific clauses, with corrective-action recommendations.
+- Delivery is **email-based**: documents in, report out. No login, no platform, no subscription in the MVP/Phase 1.
+- Modern analysis tooling speeds up the review; **every finding is reviewed and signed off by the P.Eng** before it reaches the customer. Nothing is auto-generated and shipped.
+
+> Note: the pre-repositioning pricing page implied a SaaS platform (monthly subscriptions, "conversions/month", API access). That contradicted the actual email-consulting model in CLAUDE.md and was removed in the repositioning.
+
+## 2. The problem we solve
+
+**[Established]** A small/mid-size manufacturer needs ISO 9001 certification — usually because a large customer requires it to stay on the approved-supplier list. To certify, an external auditor inspects them.
+
+The buyer is trapped between two expensive options:
+
+| Path | Cost | Source |
+|---|---|---|
+| Fail the certification audit | **$8,000–$15,000** wasted audit fees + **3–6 months** delay | pre-assessment checklist PDF |
+| Hire a traditional consultant to prevent that | **$15,000–$50,000** | competitor pricing, cited in FAQ/blog |
+
+**AuditsReady sells the cheap insurance in the middle:** find the gaps *before* the auditor does, for a fraction of either cost. The strongest single argument on the site is the failed-audit cost framing — a pre-assessment costs a fraction of a failed audit.
+
+## 3. The offer ladder (the model)
+
+**[Established]** Three rungs, each designed to de-risk the *next* purchase for a skeptical buyer who has never heard of us:
+
+```
+FREE SAMPLE            PILOT                  FULL ENGAGEMENT
+1 document        →    $597              →    $1,500
+quality manual         one process             full documentation
+or a single SOP        area                    gap analysis +
+                                               clause-by-clause report +
+real sample report     paid, real work         corrective-action roadmap +
+at no charge           filters tire-kickers    1 review call
+```
+
+| Rung | Price | Purpose | Cost to us |
+|---|---|---|---|
+| Free sample | $0 | Lead magnet + proof of quality. Buyer sees real work, not marketing. | ~1 hr P.Eng time |
+| Pilot Gap Analysis | $597 | "Just try it" tier. Small enough to approve without a PO; large enough to signal the work is real. | Bounded to one doc set |
+| Full Gap Analysis | $1,500 | **The actual product.** Buyer has seen quality twice (free + pilot), so this is a low-friction upsell. | Full engagement |
+
+**Where the revenue comes from:** the **$1,500 full engagements**. The free sample and pilot are customer-acquisition costs, funded by P.Eng labor instead of ad spend.
+
+### Why $597 for the pilot
+**[Established]** The task brief specified a $500–750 range with $597 as the default. Within that range $597 is defensible because:
+- **Charm/anchor pricing** — reads meaningfully below $600.
+- **~40% of the $1,500 full** — a real commitment that filters non-buyers, but low enough for a quality manager to approve without a purchase-order process.
+- **Clearly not "free"** — a ~$600 price signals "real paid work," protecting the perceived value of the full analysis.
+
+## 4. Unit economics — the bet that has to hold
+
+**[Assumption]** The model only works if **P.Eng hours per engagement stay low**. The entire pitch ("tooling reviews fast, engineer validates") is an economic claim: a gap analysis that costs a traditional consultant 4–8 weeks of billable hours must take a fraction of that here.
+
+Illustrative targets (to validate, not published claims):
+
+| Engagement | Price | Target P.Eng hours | Implied effective rate |
+|---|---|---|---|
+| Pilot | $597 | 2–3 hrs | ~$200–300/hr |
+| Full | $1,500 | 5–8 hrs | ~$190–300/hr |
+
+- If a full engagement eats **~40 hours**, the model is **broken** (effective rate ≈ $37/hr).
+- If it's **~5–8 hours** (tooling drafts, engineer reviews and signs off), the margin is real and competitive with the $125–250/hr consultants charge.
+
+**This is the core business bet:** tooling-assisted-but-human-validated gap analysis can be delivered fast enough that $1,500 is profitable — while staying trustworthy enough that a quality manager will stake their audit on it.
+
+## 5. Known fragilities
+
+**[Established / Assumption mixed]**
+
+- **One-time, not recurring.** A manufacturer buys a gap analysis roughly once per certification cycle. No recurring revenue in the MVP — which is *why* the old page bolted on monthly SaaS subscriptions (now removed as off-model). Recurring revenue (surveillance-audit retainers, annual re-checks, subscription re-reviews) is an **open Phase 2 question** the repo has not answered.
+- **Capacity-bound.** Revenue scales with available P.Eng hours. One engineer caps throughput. Growth requires more engineers or more automation of the drafting step (keeping human sign-off).
+- **No proof yet.** CLAUDE.md notes there are no case studies and conversion is unproven. The free → pilot → full ladder is a *hypothesis* about converting cold skeptics, not a validated funnel.
+- **Trust is the whole game.** The buyer's fear is AI-generated docs failing a real audit. The P.Eng sign-off and "nothing auto-generated and shipped" framing exist to neutralize exactly that fear. If that trust erodes, the price ladder collapses.
+
+## 6. Target customer (beachhead)
+
+**[Established]** Small and mid-size **general industrial manufacturers** (10–500 employees): building materials, packaging, plastics, metal fabrication, industrial products — preparing for certification, surveillance audits, or customer audits. Other manufacturing sectors are reachable but secondary. The buyer is a skeptical plant/quality manager, not a tech buyer.
+
+## 7. Turnaround standard
+
+**[Established]** Free single-document sample in **~24 hours**; full engagement in **~2 weeks**. (Standardized in the repositioning; the old "48–72 hours" claims were reconciled to this.)
+
+---
+
+## Open questions to resolve
+
+1. **Validate the hours-per-engagement assumption** — track actual P.Eng time on the first 5–10 real jobs. This is the make-or-break number.
+2. **Path to recurring revenue** — is there a retainer/annual-review product, or is this inherently transactional?
+3. **Capacity plan** — at what monthly volume does one P.Eng saturate, and what's the next hire/automation step?
+4. **Conversion data** — free → pilot and pilot → full conversion rates are currently unknown. The whole ladder rests on these.
+
+---
+
+**Last updated:** 2026-07-05
+**Related:** `CLAUDE.md` (positioning, pages), `public/downloads/iso-9001-pre-assessment-2026.md` (failed-audit cost framing)

--- a/claude.md
+++ b/claude.md
@@ -2,7 +2,9 @@
 
 ## Project Overview
 
-Marketing and landing page for AuditsReady, an AI-powered ISO9001 SOP compliance platform for manufacturers worldwide.
+Marketing and landing page for AuditsReady, a P.Eng-validated ISO 9001 gap analysis service for small and mid-size manufacturers.
+
+**Positioning (as of 2026-07-05):** ISO 9001 gap analysis for small and mid-size **general industrial manufacturers** (10–500 employees) — building materials, packaging, plastics, metal fabrication, and industrial products — preparing for certification, surveillance audits, or customer audits. Every finding is reviewed and signed off by a licensed Professional Engineer (P.Eng). AI/modern tooling is the *how* (speed/cost), never the headline; outputs are "drafted for your review, validated by a P.Eng" — never "auto-generated." Other manufacturing sectors are reachable via a secondary line but the hero speaks to industrial manufacturers. See the 2026-07-05 Recent Updates entry for details.
 
 **Purpose:** Customer acquisition and lead generation
 **Location:** `/Users/gjayasun/git/auditsready`
@@ -73,14 +75,14 @@ auditsready/
 
 ## Key Features
 
-### Landing Page Sections
-1. **Hero** - Value proposition with "Book AI Demo" modal CTA and phone reveal
-2. **How It Works** - 8-second demo video (auditsready-demo.mp4) + 3-step process with P.Eng trust badge + Free ISO 9001 Checklist CTA
-3. **Beyond Traditional Tools** - AI features (Claude Sonnet 4.5 + Opus capabilities)
-4. **AI Finds What Others Miss** - Gap detection and SOP conversion capabilities
-5. **Built for Every Manufacturing Business** - Universal industry messaging (automotive, aerospace, electronics, food, consumer products, textiles, plastics, metal fabrication, etc.)
-6. **Pricing/CTA** - Early adopter pricing with "Book AI Demo" modal
-7. **Footer** - Contact info with click-to-reveal phone
+### Landing Page Sections (as of 2026-07-05 repositioning)
+1. **Hero** - "Pass your ISO 9001 audit — without the $20K consultant." P.Eng trust pill + subheadline (P.Eng, 12+ yrs, building-materials/packaging) + beachhead industries line. Primary CTA: "Get a free gap analysis of your quality manual or one SOP" (opens modal); secondary CTA: "Book a 15-minute call"
+2. **How It Works** - 8-second demo video (auditsready-demo.mp4) + 3-step process (Send Documents → P.Eng Reviews the Gaps → Get Audit-Ready Findings) with factual P.Eng trust badge (APEGA, 12+ yrs) + Free ISO 9001 Checklist CTA
+3. **Why Trust Us** - Credibility proof points (licensed P.Eng/APEGA 12+ yrs; IKO Industries + WestRock experience; findings mapped to ISO 9001:2015 clauses; failed-audit cost $8K–$15K + 3–6 months) + the SINGLE AI mention, framed as speed with mandatory P.Eng validation
+4. **What You Get** - Deliverables: clause-by-clause findings, corrective action recommendations, P.Eng sign-off ("drafted for your review, validated by a P.Eng")
+5. **Built for Industrial Manufacturers** - Beachhead industries + 10-500 employees + audit milestones; secondary "different sector? just ask" line
+6. **Pricing/CTA** - Pilot Gap Analysis $597 → Full Gap Analysis $1,500; failed-audit cost framing; free-sample CTA
+7. **Footer** - Contact info with click-to-reveal phone; P.Eng sign-off tagline (no "artificial intelligence" tagline)
 
 ### Contact Form (Modal)
 - Professional modal popup with form fields (Name, Company, Email, Phone, Message)
@@ -106,20 +108,22 @@ git push origin main    # Auto-deploys to Vercel
 
 ## Target Market
 
-**Primary:** Small-medium manufacturers worldwide (10-500 employees)
-**Geographic:** Worldwide (no geographic restrictions)
-**Industries:** Any manufacturing sector - automotive, aerospace, electronics, food processing, consumer products, textiles, plastics, metal fabrication, craft breweries, oilfield services, and more
+**Primary (beachhead):** Small and mid-size **general industrial manufacturers** (10-500 employees) — building materials, packaging, plastics, metal fabrication, and industrial products — preparing for ISO 9001 certification, surveillance audits, or customer audits
+**Secondary:** Other manufacturing sectors (reachable via a secondary line, not the hero)
+**Geographic:** North America and worldwide (no hard geographic restrictions)
+**Buyer:** Skeptical plant manager or quality manager at a small/mid-size manufacturer; fears AI-generated compliance documents failing a real audit. Write for them, not a tech buyer.
 
 ## SEO Implementation
 
-### Meta Tags (Global Positioning)
-- Title: "AI-Powered ISO 9001 Gap Analysis | Audit-Ready SOP Compliance"
-- Keywords: ISO 9001 gap analysis, SOP compliance, audit preparation, automotive ISO 9001, aerospace manufacturing, electronics manufacturing, food processing ISO 9001, consumer products manufacturing
-- Emphasis on "any manufacturing industry" for broad appeal
-- Geographic scope: Worldwide
+### Meta Tags (Positioning: beachhead + P.Eng, not AI)
+- Title: "ISO 9001 Gap Analysis for Small & Mid-Size Manufacturers | P.Eng-Validated | AuditsReady"
+- Keywords: ISO 9001 gap analysis, ISO 9001 pre-assessment, ISO 9001 for small manufacturers, P.Eng validated, building materials manufacturing, packaging manufacturing, plastics manufacturing, metal fabrication, industrial products manufacturing
+- Lead with the beachhead industries + P.Eng validation; keep other sectors as secondary
+- **No "AI" in the page title or meta description.** AI may appear once, lower on the page, framed as speed/cost — always paired with mandatory P.Eng validation
+- Geographic scope: North America and worldwide
 
 ### Structured Data
-- ProfessionalService schema (Worldwide coverage with knowsAbout 13+ manufacturing sectors)
+- ProfessionalService schema (knowsAbout leads with the beachhead industries; fabricated aggregateRating removed)
 - Service schema with offerings and business audience
 - FAQPage schema with 4 strategic questions for rich snippets
 - Phone number visible to crawlers in structured data
@@ -167,10 +171,19 @@ RESEND_API_KEY=re_your_key_here  # Get from https://resend.com/api-keys
   - compliance@auditsready.com (Compliance queries - routes to team)
   - noreply@auditsready.com (Automated emails only)
 - **Phone:** +1-403-404-4643 (click-to-reveal component)
-- **Serving:** Worldwide - any manufacturing industry
+- **Serving:** North America and worldwide — beachhead is small/mid-size industrial manufacturers (building materials, packaging, plastics, metal fabrication, industrial products); other sectors reachable via secondary line
 - **Contact Form:** Modal popup with Resend API integration
 
 ## Recent Updates
+
+### 2026-07-05: Repositioning — Industrial Manufacturing Beachhead + P.Eng-Led (branch: reposition-manufacturing)
+- 🎯 **New positioning**: Away from "AI-Powered ISO 9001 | Any Manufacturing Industry" (which was failing to convert) toward **P.Eng-validated ISO 9001 gap analysis for small/mid-size general industrial manufacturers** (building materials, packaging, plastics, metal fabrication, industrial products; 10-500 employees). Two problems being fixed: (1) generalist "any industry/size/worldwide" is no positioning; (2) "AI-powered" as the headline scares the buyer (a quality manager who fears AI-generated docs failing a real audit). AI is the *how*, not the headline.
+- ✅ **`pages/index.js`**: Hero rewrite ("Pass your ISO 9001 audit — without the $20K consultant."), P.Eng trust pill, free-gap-analysis primary CTA + 15-min call secondary. Demoted AI to a single speed/cost mention with mandatory P.Eng validation. Added "Why Trust Us" credibility section (proof points + $8K–$15K failed-audit framing reused from the pre-assessment checklist) and "What You Get" deliverables. Replaced generalist section with "Built for Industrial Manufacturers." Added Pilot $597 → Full $1,500 offer. Rewrote title/meta/OG/Twitter + all JSON-LD; removed fabricated 5.0 aggregateRating.
+- ✅ **`pages/pricing.js`**: Replaced per-25-document packages ($1,500/$2,500/$4,500) and monthly SaaS subscriptions ($99/$299/$999) with **Pilot $597 → Full $1,500** gap-analysis offer. Rebuilt cost-comparison table; removed fabricated ROI numbers. De-AI'd title/meta/JSON-LD/copy/footer; dropped "AI generates SOPs" claim.
+- ✅ **`pages/faq.js`**: Reconciled turnaround to **~2 weeks** (was "48-72 hours"); reframed AI answers (tooling is the *how*, P.Eng validates every finding, drafts are for review — never auto-shipped); updated pricing refs to $597/$1,500; de-AI'd meta + bottom CTA.
+- 📐 **Turnaround standard**: Free single-document sample in ~24 hours; full engagement in ~2 weeks.
+- ⚠️ **NOT yet done (intentional)**: (1) **Blog** (`pages/blog/index.js` + 13 post bodies, ~40,000 words) still AI-forward — two index excerpts say "AI-powered" and post #11 is literally "Traditional ISO Consultants vs. AI"; realigning is a separate large effort. (2) Logo filename still `iso-9001-ai-powered-compliance-auditsready-logo.png` (cosmetic). (3) `public/sitemap.xml` tone still generalist. (4) The MVP pricing model and lead-magnet copy below in this file still reference the old package/subscription framing where noted.
+- 📦 **Status**: On branch `reposition-manufacturing` (2 commits), not pushed, no PR — awaiting owner review per instruction.
 
 ### 2026-01-28: Blog Content Phase 1 Complete (13/13 Posts)
 - ✅ **3 New Blog Posts Published**: Completing the 13-post content strategy
@@ -325,7 +338,7 @@ RESEND_API_KEY=re_your_key_here  # Get from https://resend.com/api-keys
 - ✅ FAQ page with 28 questions live
 - ✅ 4 legal pages deployed (Terms, Privacy, Refund, Acceptable Use)
 - ✅ Contact form with Resend API integration on all pages
-- ✅ Universal "any manufacturing industry" positioning
+- ✅ Positioning: P.Eng-validated ISO 9001 gap analysis for small/mid-size industrial manufacturers (beachhead) — homepage/pricing/FAQ updated on branch `reposition-manufacturing`; `main` still shows the prior "any manufacturing industry" positioning until merged
 - ✅ 8-second demo video in "How It Works" section
 - ✅ Lead magnet deliverables created (checklist, roadmap, template)
 - 📊 Total content: 40,000+ words across 13 blog posts + FAQ
@@ -562,8 +575,9 @@ Based on SEO research and current manufacturing challenges, these topics target 
 
 ### Common Tasks
 - Phone/Email updates: `pages/index.js` PhoneReveal component
-- Industries: `pages/index.js` industries section
-- SEO: Update `<Head>` meta tags and structured data
+- Industries: `pages/index.js` "Built for Industrial Manufacturers" section (lead with beachhead industries; keep "other sectors? just ask" secondary line)
+- SEO: Update `<Head>` meta tags and structured data (keep "AI" out of homepage/pricing titles + meta descriptions)
+- Positioning guardrails: never claim outputs are "auto-generated"/"AI-generated"; frame as "drafted for your review, validated by a P.Eng"; AI appears at most once per page as speed/cost, always paired with P.Eng validation
 - Blog posts: Create feature branch → write post → test locally → commit → push → PR → merge
 
 ## Known Issues
@@ -802,8 +816,8 @@ Based on SEO research and current manufacturing challenges, these topics target 
 
 ---
 
-**Last Updated:** 2026-01-28
-**Branch:** main
+**Last Updated:** 2026-07-05
+**Branch:** reposition-manufacturing (repositioning in review; main is still the deployed positioning)
 **Deployment:** Live on Vercel via GitHub integration
 
 ## Email Configuration
@@ -933,6 +947,6 @@ If you ever need to verify another domain or re-verify:
 
 ---
 
-**Last Updated:** 2026-01-28
-**Branch:** main
+**Last Updated:** 2026-07-05
+**Branch:** reposition-manufacturing (repositioning in review; main is still the deployed positioning)
 **Deployment:** Live on Vercel via GitHub integration

--- a/claude.md
+++ b/claude.md
@@ -9,6 +9,7 @@ Marketing and landing page for AuditsReady, a P.Eng-validated ISO 9001 gap analy
 **Purpose:** Customer acquisition and lead generation
 **Location:** `/Users/gjayasun/git/auditsready`
 **Live Site:** https://auditsready.com
+**Business model:** See `BUSINESS_MODEL.md` — productized P.Eng consulting; free sample → $597 pilot → $1,500 full engagement; revenue from full engagements; margin depends on keeping P.Eng hours-per-job low (unvalidated). Marks [Established] vs [Assumption] facts.
 
 ## Technology Stack
 

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -192,19 +192,19 @@ export default function FAQ() {
       questions: [
         {
           q: "How much does ISO 9001 certification cost for a small manufacturer?",
-          a: "For small manufacturers (10-50 employees), total ISO 9001 certification costs typically range from $15,000-$50,000 with traditional consultants:\n\n• Consultant fees: $10k-$30k\n• Certification body fees: $3k-$8k\n• Internal costs: $2k-$12k\n\nWith AuditsReady's AI-powered approach, you can reduce consultant costs to $1,500-$5,000 while maintaining P.Eng validation. The exact cost depends on your current documentation quality, number of processes, and timeline urgency."
+          a: "For small manufacturers (10-50 employees), total ISO 9001 certification costs typically range from $15,000-$50,000 with traditional consultants:\n\n• Consultant fees: $10k-$30k\n• Certification body fees: $3k-$8k\n• Internal costs: $2k-$12k\n\nAuditsReady replaces the consultant gap-analysis phase with a P.Eng-validated review: a $597 pilot or a $1,500 full gap analysis. You get a clear list of what to fix, mapped to ISO 9001:2015 clauses, then handle implementation with your own team. The exact cost depends on your current documentation quality, number of processes, and timeline."
         },
         {
           q: "How long does ISO 9001 certification take?",
-          a: "Most manufacturers complete ISO 9001 certification in 6-12 months. The timeline includes:\n\n• Gap analysis: 1-2 weeks\n• Documentation development: 2-4 months\n• Implementation: 2-4 months\n• Internal audits: 1 month\n• Certification audit: 1-2 months\n\nWith AuditsReady's AI-powered gap analysis (48-72 hours) and streamlined approach, you can compress this to 3-6 months if you have some existing documentation and dedicated internal resources."
+          a: "Most manufacturers complete ISO 9001 certification in 6-12 months. The timeline includes:\n\n• Gap analysis: 1-2 weeks\n• Documentation development: 2-4 months\n• Implementation: 2-4 months\n• Internal audits: 1 month\n• Certification audit: 1-2 months\n\nWith AuditsReady's P.Eng-validated gap analysis (about 2 weeks) and a focused action plan, you can compress this to 3-6 months if you have some existing documentation and dedicated internal resources."
         },
         {
           q: "Can I get ISO 9001 in 3 months?",
-          a: "Yes, but only under specific conditions:\n\n• You already have documented processes\n• You have a dedicated quality manager or team\n• Your documentation is mostly compliant with minor gaps\n• You can schedule a certification audit quickly\n\nAuditsReady's AI can identify gaps in 48-72 hours, helping you focus immediately on critical issues. However, rushing certification often leads to failures or major non-conformances. We recommend 6 months as a realistic fast-track timeline for most manufacturers."
+          a: "Yes, but only under specific conditions:\n\n• You already have documented processes\n• You have a dedicated quality manager or team\n• Your documentation is mostly compliant with minor gaps\n• You can schedule a certification audit quickly\n\nAuditsReady's P.Eng-validated gap analysis (about 2 weeks) helps you focus immediately on the critical issues. However, rushing certification often leads to failures or major non-conformances. We recommend 6 months as a realistic fast-track timeline for most manufacturers."
         },
         {
           q: "What's the fastest way to get ISO 9001 certified?",
-          a: "The fastest path combines:\n\n• AI-powered gap analysis to identify issues immediately (AuditsReady provides this in 48-72 hours)\n• Focus on mandatory documentation only (skip nice-to-have procedures initially)\n• Parallel workflows (develop docs while implementing processes)\n• Dedicated internal champion (quality manager or owner commitment)\n• Pre-audit with consultant before official certification audit\n\nAvoid shortcuts like generic templates or skipping implementation—these lead to audit failures and delays."
+          a: "The fastest path combines:\n\n• A gap analysis to identify issues early (AuditsReady delivers a P.Eng-validated report in about 2 weeks)\n• Focus on mandatory documentation only (skip nice-to-have procedures initially)\n• Parallel workflows (develop docs while implementing processes)\n• Dedicated internal champion (quality manager or owner commitment)\n• Pre-audit before your official certification audit\n\nAvoid shortcuts like generic templates or skipping implementation—these lead to audit failures and delays."
         },
         {
           q: "What are the 10 clauses of ISO 9001:2015?",
@@ -221,7 +221,7 @@ export default function FAQ() {
         },
         {
           q: "Is ISO 9001 too complicated for a small business?",
-          a: "No, ISO 9001 is scalable to any company size. The standard doesn't dictate how much documentation you need—a 5-person job shop can have simpler procedures than a 500-person factory. The key is documenting what you actually do, not creating bureaucracy. Many small manufacturers think ISO 9001 means endless paperwork, but modern approaches (like AuditsReady's AI-powered gap analysis) simplify compliance. Focus on the 20% of processes that drive 80% of your quality, and scale documentation to your actual complexity."
+          a: "No, ISO 9001 is scalable to any company size. The standard doesn't dictate how much documentation you need—a 5-person job shop can have simpler procedures than a 500-person factory. The key is documenting what you actually do, not creating bureaucracy. Many small manufacturers think ISO 9001 means endless paperwork, but a focused gap analysis (like AuditsReady's P.Eng-validated review) shows you what actually matters. Focus on the 20% of processes that drive 80% of your quality, and scale documentation to your actual complexity."
         },
         {
           q: "What happens if I fail my ISO 9001 audit?",
@@ -236,15 +236,15 @@ export default function FAQ() {
       questions: [
         {
           q: "Can I get ISO 9001 certified without a consultant?",
-          a: "Yes, but it's challenging and time-consuming. DIY certification works if:\n\n• You have strong internal expertise (quality manager with ISO experience)\n• You can commit 200-500 hours to documentation\n• You understand audit requirements\n• You have good existing processes\n\nMost small manufacturers struggle with interpretation of requirements and audit preparation. AuditsReady offers a middle path: AI-powered gap analysis ($1,500-$5,000) gives you the roadmap, and you do the implementation work. This saves 60-80% vs. full consultant fees while avoiding DIY pitfalls."
+          a: "Yes, but it's challenging and time-consuming. DIY certification works if:\n\n• You have strong internal expertise (quality manager with ISO experience)\n• You can commit 200-500 hours to documentation\n• You understand audit requirements\n• You have good existing processes\n\nMost small manufacturers struggle with interpretation of requirements and audit preparation. AuditsReady offers a middle path: a P.Eng-validated gap analysis (pilot from $597, full engagement $1,500) gives you the roadmap, and you do the implementation work. This costs far less than full consultant fees while avoiding DIY pitfalls."
         },
         {
           q: "Is ISO 9001 worth the cost?",
-          a: "For most manufacturers, yes. ROI comes from:\n\n• Customer requirements (many contracts require ISO 9001)\n• Reduced defects (10-30% quality improvement typical)\n• Operational efficiency (streamlined processes save 5-15% in costs)\n• Competitive advantage (preferred supplier status)\n• Better employee training\n\nBreak-even is typically 12-24 months. If you're losing contracts due to lack of certification, ROI is immediate. If you're pursuing certification for internal improvement only, calculate savings from reduced rework, scrap, and customer complaints. For small manufacturers with tight margins, AI-powered consulting (like AuditsReady) reduces upfront costs from $15k-$50k to $1,500-$5,000, improving ROI significantly."
+          a: "For most manufacturers, yes. ROI comes from:\n\n• Customer requirements (many contracts require ISO 9001)\n• Reduced defects (10-30% quality improvement typical)\n• Operational efficiency (streamlined processes save 5-15% in costs)\n• Competitive advantage (preferred supplier status)\n• Better employee training\n\nBreak-even is typically 12-24 months. If you're losing contracts due to lack of certification, ROI is immediate. If you're pursuing certification for internal improvement only, calculate savings from reduced rework, scrap, and customer complaints. For small manufacturers with tight margins, a P.Eng-validated gap analysis (like AuditsReady, pilot from $597 or $1,500 for the full engagement) cuts the upfront gap-analysis cost dramatically versus a traditional consultant, improving ROI."
         },
         {
           q: "How much does an ISO 9001 consultant charge?",
-          a: "Traditional ISO 9001 consultants charge $125-$250/hour or $10,000-$50,000 per project, depending on company size and complexity.\n\nTypical breakdown:\n• Small manufacturer (10-50 employees) = $15k-$25k\n• Mid-size (50-200 employees) = $25k-$40k\n• Large (200+ employees) = $40k-$100k+\n\nThese fees cover gap analysis, documentation, training, and audit preparation. AuditsReady uses AI to reduce costs to $1,500-$5,000 for gap analysis and recommendations, with optional ongoing support. You save 70-85% by doing implementation yourself with AI guidance."
+          a: "Traditional ISO 9001 consultants charge $125-$250/hour or $10,000-$50,000 per project, depending on company size and complexity.\n\nTypical breakdown:\n• Small manufacturer (10-50 employees) = $15k-$25k\n• Mid-size (50-200 employees) = $25k-$40k\n• Large (200+ employees) = $40k-$100k+\n\nThese fees cover gap analysis, documentation, training, and audit preparation. AuditsReady focuses on the gap-analysis phase: a $597 pilot or a $1,500 full engagement, with findings mapped to ISO 9001:2015 clauses and signed off by a licensed P.Eng. You save a large share of the cost by handling implementation yourself with a clear roadmap."
         }
       ]
     },
@@ -309,7 +309,7 @@ export default function FAQ() {
       questions: [
         {
           q: "Can AI help with ISO 9001 compliance?",
-          a: "Yes! AI excels at:\n\n• Gap analysis (scanning your documents to identify missing requirements in 48-72 hours vs. 2-4 weeks manually)\n• Documentation generation (creating first-draft SOPs based on your inputs)\n• Audit preparation (predicting likely audit findings)\n• Continuous monitoring (future capability—AI tracking non-conformances and corrective actions)\n\nAuditsReady combines AI-powered gap detection with P.Eng (Professional Engineer) validation to ensure accuracy. AI alone isn't enough—you need expert review to catch nuances auditors care about. Our hybrid model gives you speed of AI plus credibility of professional validation. AI reduces consultant costs by 70-85% while maintaining quality."
+          a: "Modern analysis tooling helps with:\n\n• Gap analysis (reviewing documents against ISO 9001 requirements faster than a fully manual read)\n• Draft procedures (a starting point you review and edit—never shipped as-is)\n• Audit preparation (surfacing likely audit findings to check)\n\nAt AuditsReady, tooling is only the how. Every finding is reviewed and validated by a licensed Professional Engineer (P.Eng) before it reaches you. Nothing is auto-generated and shipped. That combination gives you speed without the audit risk of unchecked, machine-written compliance documents—at a fraction of a traditional consultant's cost."
         },
         {
           q: "Is AI-generated ISO 9001 documentation acceptable to auditors?",
@@ -317,7 +317,7 @@ export default function FAQ() {
         },
         {
           q: "What's better: hiring a consultant or using software for ISO 9001?",
-          a: "Neither extreme is ideal—a hybrid approach works best. Traditional consultants ($15k-$50k) provide expertise but are expensive and slow. Software-only tools ($500-$5,000) are fast and cheap but require you to interpret ISO 9001, risking gaps.\n\nAuditsReady's hybrid model combines:\n• AI for speed and cost savings (gap analysis in 48-72 hours)\n• P.Eng validation for accuracy and credibility\n• Your implementation for cost control (you do the work, AI guides you)\n\nThis gives you 70-85% cost savings vs. full consultants while avoiding DIY mistakes. Choose based on your internal expertise: strong quality team = software-only, no expertise = full consultant, some capability = hybrid (AuditsReady)."
+          a: "Neither extreme is ideal—a hybrid approach works best. Traditional consultants ($15k-$50k) provide expertise but are expensive and slow. Software-only tools ($500-$5,000) are fast and cheap but require you to interpret ISO 9001, risking gaps.\n\nAuditsReady's model combines:\n• Modern tooling for speed (gap analysis in about 2 weeks)\n• P.Eng validation for accuracy and credibility—every finding signed off by a licensed engineer\n• Your implementation for cost control (you do the work with a clear roadmap)\n\nThis costs far less than a full consultant while avoiding DIY mistakes. Choose based on your internal expertise: strong quality team = software-only, no expertise = full consultant, some capability = a P.Eng-validated gap analysis (AuditsReady)."
         }
       ]
     },
@@ -328,7 +328,7 @@ export default function FAQ() {
       questions: [
         {
           q: "Where can I find ISO 9001 consultants near me?",
-          a: "While local consultants exist, location matters less for ISO 9001 consulting than you think. Modern consulting is remote-first (COVID proved this)—most documentation, training, and audit prep happens via email, video calls, and document sharing.\n\nLocal consultants charge premium rates ($150-$300/hour) due to travel time and limited competition. Remote consultants (like AuditsReady) offer 50-70% cost savings without sacrificing quality.\n\nThat said, if you prefer on-site visits: search \"ISO 9001 consultant [your city]\" or check ASQC, ASQ, or LinkedIn. For most small manufacturers, remote AI-powered consulting delivers faster results at lower cost. AuditsReady serves manufacturers worldwide—location doesn't limit our service quality."
+          a: "While local consultants exist, location matters less for ISO 9001 consulting than you think. Modern consulting is remote-first (COVID proved this)—most documentation, training, and audit prep happens via email, video calls, and document sharing.\n\nLocal consultants charge premium rates ($150-$300/hour) due to travel time and limited competition. Remote consultants (like AuditsReady) offer 50-70% cost savings without sacrificing quality.\n\nThat said, if you prefer on-site visits: search \"ISO 9001 consultant [your city]\" or check ASQC, ASQ, or LinkedIn. For most small manufacturers, remote gap analysis delivers faster results at lower cost. AuditsReady serves manufacturers in North America and worldwide—location doesn't limit our service quality."
         },
         {
           q: "Do I need an on-site consultant for ISO 9001?",
@@ -363,7 +363,7 @@ export default function FAQ() {
       <ContactFormModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
       <Head>
         <title>ISO 9001 FAQ: 28 Questions Answered by Experts | AuditsReady</title>
-        <meta name="description" content="Get answers to the 28 most common ISO 9001 questions about cost, timeline, requirements, and certification. Free advice from P.Eng validated consultants." />
+        <meta name="description" content="Answers to 28 common ISO 9001 questions on cost, timeline, requirements, and certification for small and mid-size manufacturers. Reviewed by a licensed Professional Engineer (P.Eng)." />
         <meta name="keywords" content="iso 9001 faq, iso 9001 questions, iso 9001 cost, iso 9001 requirements, iso certification questions, iso 9001 timeline" />
         <meta name="robots" content="index, follow" />
 
@@ -477,7 +477,7 @@ export default function FAQ() {
         <div className="bg-gradient-to-r from-blue-900 to-indigo-900 rounded-2xl shadow-2xl p-8 text-white text-center mt-16">
           <h2 className="text-3xl font-bold mb-4">Ready to Get Started with ISO 9001?</h2>
           <p className="text-xl text-blue-100 mb-6">
-            Get AI-powered gap analysis in 48-72 hours. P.Eng validated. Starting at $1,500.
+            Send us one document for a free sample gap analysis. Pilot from $597, full engagement $1,500 — every finding signed off by a licensed P.Eng.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <button

--- a/pages/index.js
+++ b/pages/index.js
@@ -105,7 +105,7 @@ function ContactFormModal({ isOpen, onClose }) {
       <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
         <div className="p-8">
           <div className="flex justify-between items-center mb-6">
-            <h2 className="text-3xl font-bold text-gray-900">Schedule Your Free Call</h2>
+            <h2 className="text-3xl font-bold text-gray-900">Get Your Free Gap Analysis</h2>
             <button
               onClick={onClose}
               className="text-gray-400 hover:text-gray-600 text-3xl leading-none"
@@ -115,7 +115,8 @@ function ContactFormModal({ isOpen, onClose }) {
           </div>
 
           <p className="text-gray-600 mb-6">
-            Fill out the form below and we'll contact you within 24 hours to schedule your free 15-minute consultation.
+            Send us one document — your quality manual or a single SOP — and we'll return a real sample gap analysis at no charge.
+            Attach it here or email it to info@auditsready.com. Prefer to talk first? Ask for a 15-minute call in the message below.
           </p>
 
           <form onSubmit={handleSubmit}>
@@ -185,21 +186,21 @@ function ContactFormModal({ isOpen, onClose }) {
                   value={formData.message}
                   onChange={(e) => setFormData({ ...formData, message: e.target.value })}
                   className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  placeholder="Tell us about your ISO 9001 compliance needs..."
+                  placeholder="What are you preparing for — certification, a surveillance audit, or a customer audit? Roughly how many documents do you have? (Or ask for a 15-minute call.)"
                 />
               </div>
             </div>
 
             <div className="mt-6 bg-blue-50 border border-blue-200 rounded-lg p-4">
               <p className="text-sm text-blue-800">
-                ✓ We'll contact you within 24 hours to schedule your free 15-minute consultation
+                ✓ We reply within 24 hours. Every gap analysis is reviewed and signed off by a licensed P.Eng.
               </p>
             </div>
 
             {submitStatus === 'success' && (
               <div className="mt-4 bg-green-50 border border-green-200 rounded-lg p-4">
                 <p className="text-green-800 font-semibold">✓ Thank you! Your request has been submitted successfully.</p>
-                <p className="text-green-700 text-sm mt-1">We'll contact you within 24 hours to schedule your free 15-minute consultation.</p>
+                <p className="text-green-700 text-sm mt-1">We'll reply within 24 hours. If you attached or emailed a document, we'll send back a sample gap analysis at no charge.</p>
               </div>
             )}
 
@@ -240,17 +241,17 @@ export default function Home() {
     <div className="bg-gradient-to-br from-slate-50 to-blue-50 min-h-screen">
       <ContactFormModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
       <Head>
-        <title>AuditsReady - AI-Powered ISO 9001 Gap Analysis for Manufacturers</title>
-        <meta name="description" content="Get ISO 9001 audit-ready in weeks, not months. AI finds your compliance gaps, generates SOPs, and a P.Eng validates everything. For manufacturers 10-500 employees. Free gap analysis, 48-hour turnaround." />
+        <title>ISO 9001 Gap Analysis for Small & Mid-Size Manufacturers | P.Eng-Validated | AuditsReady</title>
+        <meta name="description" content="Pass your ISO 9001 audit without a $20K consultant. Gap analysis for small and mid-size manufacturers, reviewed and signed off by a licensed Professional Engineer (P.Eng). Audit-ready findings in 2 weeks, at a fraction of consultant cost." />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="robots" content="index, follow" />
         <meta name="author" content="AuditsReady" />
-        <meta name="keywords" content="ISO 9001 gap analysis, ISO 9001 consultant, SOP compliance, manufacturing audit preparation, ISO certification service, quality management system, audit-ready documentation, SOP conversion, any manufacturing industry, all manufacturing sectors, automotive ISO 9001, aerospace manufacturing, electronics manufacturing, food processing ISO 9001, consumer products manufacturing, textile manufacturing, plastics manufacturing" />
+        <meta name="keywords" content="ISO 9001 gap analysis, ISO 9001 pre-assessment, ISO 9001 for small manufacturers, ISO 9001 certification, surveillance audit, customer audit, quality management system, P.Eng validated, building materials manufacturing, packaging manufacturing, plastics manufacturing, metal fabrication, industrial products manufacturing, quality manual review, SOP gap analysis" />
         <link rel="canonical" href="https://auditsready.com" />
 
         {/* OpenGraph Meta Tags */}
-        <meta property="og:title" content="AI-Powered ISO 9001 Gap Analysis | Any Manufacturing Industry" />
-        <meta property="og:description" content="AI-powered ISO 9001 compliance for any manufacturing industry worldwide. Automated gap analysis and ISO 9001-compliant SOP generation. P.Eng validated for all manufacturing sectors." />
+        <meta property="og:title" content="ISO 9001 Gap Analysis for Small & Mid-Size Manufacturers | P.Eng-Validated" />
+        <meta property="og:description" content="Pass your ISO 9001 audit without a $20K consultant. Gap analysis for small and mid-size manufacturers, reviewed and signed off by a licensed P.Eng. Audit-ready findings in 2 weeks." />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://auditsready.com" />
         <meta property="og:image" content="https://auditsready.com/iso-9001-ai-powered-compliance-auditsready-logo.png" />
@@ -259,8 +260,8 @@ export default function Home() {
 
         {/* Twitter Meta Tags */}
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="AI-Powered ISO 9001 Gap Analysis | Any Manufacturing Industry" />
-        <meta name="twitter:description" content="AI-powered ISO 9001 compliance for any manufacturing industry. Automated gap analysis and ISO 9001-compliant SOP generation. P.Eng validated worldwide." />
+        <meta name="twitter:title" content="ISO 9001 Gap Analysis for Small & Mid-Size Manufacturers | P.Eng-Validated" />
+        <meta name="twitter:description" content="Pass your ISO 9001 audit without a $20K consultant. Gap analysis for small and mid-size manufacturers, signed off by a licensed P.Eng. Audit-ready findings in 2 weeks." />
         <meta name="twitter:image" content="https://auditsready.com/iso-9001-ai-powered-compliance-auditsready-logo.png" />
 
         {/* Favicon and Icons */}
@@ -276,7 +277,7 @@ export default function Home() {
               "@context": "https://schema.org",
               "@type": "ProfessionalService",
               "name": "AuditsReady",
-              "description": "AI-powered ISO 9001 compliance and SOP gap analysis service for any manufacturing industry worldwide. Serving automotive, aerospace, electronics, food processing, consumer products, textiles, plastics, metal fabrication, and all manufacturing sectors. P.Eng validated audit preparation.",
+              "description": "ISO 9001 gap analysis for small and mid-size manufacturers preparing for certification, surveillance audits, or customer audits. Every finding is reviewed and signed off by a licensed Professional Engineer (P.Eng) with 12+ years of manufacturing quality experience. Focused on general industrial manufacturing: building materials, packaging, plastics, metal fabrication, and industrial products.",
               "url": "https://auditsready.com",
               "logo": "https://auditsready.com/iso-9001-ai-powered-compliance-auditsready-logo.png",
               "image": "https://auditsready.com/iso-9001-ai-powered-compliance-auditsready-logo.png",
@@ -289,18 +290,18 @@ export default function Home() {
               },
               "knowsAbout": [
                 "ISO 9001 Certification",
+                "ISO 9001 Gap Analysis",
+                "ISO 9001 Pre-Assessment",
                 "Quality Management Systems",
-                "Manufacturing Compliance",
-                "Automotive Manufacturing",
-                "Aerospace Manufacturing",
-                "Electronics Manufacturing",
-                "Food Processing",
-                "Consumer Products Manufacturing",
-                "Textile Manufacturing",
+                "Building Materials Manufacturing",
+                "Packaging Manufacturing",
                 "Plastics Manufacturing",
                 "Metal Fabrication",
-                "SOP Documentation",
-                "Gap Analysis"
+                "Industrial Products Manufacturing",
+                "Surveillance Audit Preparation",
+                "Customer Audit Preparation",
+                "Corrective Action Planning",
+                "Quality Manual Review"
               ],
               "contactPoint": {
                 "@type": "ContactPoint",
@@ -309,12 +310,7 @@ export default function Home() {
                 "contactType": "Customer Service",
                 "availableLanguage": ["English", "en"]
               },
-              "sameAs": [],
-              "aggregateRating": {
-                "@type": "AggregateRating",
-                "ratingValue": "5.0",
-                "reviewCount": "1"
-              }
+              "sameAs": []
             })
           }}
         />
@@ -326,9 +322,9 @@ export default function Home() {
             __html: JSON.stringify({
               "@context": "https://schema.org",
               "@type": "Service",
-              "serviceType": "ISO 9001 Compliance Consulting",
-              "name": "AI-Powered ISO 9001 Compliance for All Manufacturing Industries",
-              "description": "Automated gap analysis and ISO 9001-compliant SOP generation for any manufacturing sector worldwide",
+              "serviceType": "ISO 9001 Gap Analysis",
+              "name": "ISO 9001 Gap Analysis for Small & Mid-Size Manufacturers",
+              "description": "P.Eng-validated ISO 9001 gap analysis for small and mid-size manufacturers preparing for certification, surveillance audits, or customer audits. Findings mapped to specific ISO 9001:2015 clauses with corrective action recommendations.",
               "provider": {
                 "@type": "Organization",
                 "name": "AuditsReady",
@@ -340,34 +336,34 @@ export default function Home() {
               },
               "audience": {
                 "@type": "BusinessAudience",
-                "audienceType": "Manufacturing Companies of All Sizes and Industries"
+                "audienceType": "Small and mid-size manufacturers (10-500 employees) in building materials, packaging, plastics, metal fabrication, and industrial products"
               },
               "hasOfferCatalog": {
                 "@type": "OfferCatalog",
-                "name": "ISO 9001 Compliance Services",
+                "name": "ISO 9001 Gap Analysis Services",
                 "itemListElement": [
                   {
                     "@type": "Offer",
                     "itemOffered": {
                       "@type": "Service",
-                      "name": "AI-Powered ISO 9001 Gap Analysis",
-                      "description": "Automated gap detection and compliance mapping"
+                      "name": "Pilot Gap Analysis",
+                      "description": "Gap analysis of your quality manual or one process area, mapped to ISO 9001:2015 clauses and validated by a licensed P.Eng. A low-risk first step before a full engagement."
                     }
                   },
                   {
                     "@type": "Offer",
                     "itemOffered": {
                       "@type": "Service",
-                      "name": "SOP Document Conversion",
-                      "description": "Transform handwritten procedures into audit-ready documentation"
+                      "name": "Full Documentation Gap Analysis",
+                      "description": "Full documentation gap analysis, clause-by-clause findings report, corrective action roadmap, and one review call. Every finding reviewed and signed off by a licensed P.Eng."
                     }
                   },
                   {
                     "@type": "Offer",
                     "itemOffered": {
                       "@type": "Service",
-                      "name": "P.Eng Validated Audit Preparation",
-                      "description": "Professional Engineer validated compliance consulting"
+                      "name": "Free Sample Gap Analysis",
+                      "description": "Upload or email one document (quality manual or a single SOP) and receive a real sample gap analysis at no charge."
                     }
                   }
                 ]
@@ -386,34 +382,34 @@ export default function Home() {
               "mainEntity": [
                 {
                   "@type": "Question",
-                  "name": "What industries does AuditsReady serve?",
+                  "name": "Who is AuditsReady for?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "AuditsReady serves any kind of manufacturing industry worldwide, including automotive, aerospace, electronics, food processing, consumer products, textiles, plastics, metal fabrication, and all other manufacturing sectors seeking ISO 9001 certification."
+                    "text": "Small and mid-size manufacturers (10-500 employees) preparing for ISO 9001 certification, surveillance audits, or customer audits. We focus on general industrial manufacturing: building materials, packaging, plastics, metal fabrication, and industrial products. We work with other manufacturing sectors as well."
                   }
                 },
                 {
                   "@type": "Question",
-                  "name": "How does AI-powered gap analysis work?",
+                  "name": "Who reviews the gap analysis?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Our AI system automatically scans your existing SOPs and documentation to identify gaps, missing procedures, and compliance issues. It maps your processes to ISO 9001 requirements and provides intelligent recommendations, all validated by a licensed Professional Engineer (P.Eng)."
+                    "text": "Every finding is reviewed and signed off by a licensed Professional Engineer (P.Eng, APEGA) with 12+ years of manufacturing quality experience at building-materials and packaging plants. We use modern analysis tooling to work fast, but nothing is auto-generated and shipped. A P.Eng validates everything before it reaches you."
                   }
                 },
                 {
                   "@type": "Question",
-                  "name": "What company sizes can use AuditsReady?",
+                  "name": "What do I receive?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "AuditsReady serves manufacturing companies of all sizes, from small 5-person job shops to large 500+ employee production facilities. Our AI-powered platform scales to your needs regardless of company size."
+                    "text": "Audit-ready findings mapped to specific ISO 9001:2015 clauses, with corrective action recommendations. The full engagement includes a documentation gap analysis, a clause-by-clause findings report, a corrective action roadmap, and one review call. Turnaround is about 2 weeks."
                   }
                 },
                 {
                   "@type": "Question",
-                  "name": "Is the service available worldwide?",
+                  "name": "How much does it cost?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes, AuditsReady provides AI-powered ISO 9001 compliance services to manufacturers worldwide, including North America, Europe, Asia, and all other regions globally."
+                    "text": "A Pilot Gap Analysis of your quality manual or one process area is $597, positioned as a first step. The full documentation gap analysis is $1,500. A failed certification audit typically costs $8,000-$15,000 in wasted audit fees plus 3-6 months of delay, so a pre-assessment costs a fraction of that. You can also send one document for a free sample gap analysis."
                   }
                 }
               ]
@@ -449,30 +445,39 @@ export default function Home() {
       <header className="relative overflow-hidden bg-gradient-to-br from-blue-900 via-blue-800 to-indigo-900">
         <div className="absolute inset-0 bg-black opacity-10"></div>
         <div className="relative max-w-7xl mx-auto px-4 py-20 text-center text-white">
-          <h1 className="text-5xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-white to-blue-200 bg-clip-text text-transparent">
-            Audit-Ready SOP Compliance for Manufacturing
+          {/* P.Eng trust line */}
+          <div className="inline-flex items-center gap-2 bg-white/10 border border-white/20 rounded-full px-5 py-2 mb-8 text-sm font-semibold text-blue-50">
+            <span className="text-lg">🛡️</span>
+            Reviewed and signed off by a licensed Professional Engineer (P.Eng)
+          </div>
+          <h1 className="text-4xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-white to-blue-200 bg-clip-text text-transparent">
+            Pass your ISO 9001 audit — without the $20K consultant.
           </h1>
-          <h2 className="text-2xl md:text-3xl font-light mb-8 text-blue-100">
-            AI-powered Gap Detection • Pass Every Audit
-          </h2>
-          <p className="text-xl max-w-3xl mx-auto mb-10 text-blue-100 leading-relaxed">
-            Our smart system automatically finds missing procedures and transforms your documentation 
-            into professional, audit-ready formats. Personal service meets proven technology.
+          <p className="text-xl max-w-3xl mx-auto mb-6 text-blue-100 leading-relaxed">
+            Gap analysis for small and mid-size manufacturers, reviewed and signed off by a licensed
+            Professional Engineer (P.Eng) with 12+ years of manufacturing quality experience at
+            building-materials and packaging plants. Audit-ready findings in 2 weeks, at a fraction of consultant cost.
           </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <p className="text-base max-w-3xl mx-auto mb-10 text-blue-200">
+            Built for building materials, packaging, plastics, metal fabrication, and industrial products —
+            10 to 500 employees. Other manufacturing sectors welcome.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
             <button
               onClick={() => setIsModalOpen(true)}
               className="inline-block bg-gradient-to-r from-orange-500 to-red-500 text-white px-8 py-4 rounded-full text-lg font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 transition-all duration-300"
             >
-              Book Free Call
+              Get a free gap analysis of your quality manual or one SOP
             </button>
-            <PhoneReveal
-              buttonStyle="inline-block border-2 border-white text-white px-8 py-4 rounded-full text-lg font-semibold hover:bg-white hover:text-blue-900 transition-all duration-300"
-              buttonText="📞 Call Us Today"
-            />
+            <button
+              onClick={() => setIsModalOpen(true)}
+              className="inline-block border-2 border-white text-white px-8 py-4 rounded-full text-lg font-semibold hover:bg-white hover:text-blue-900 transition-all duration-300"
+            >
+              Book a 15-minute call
+            </button>
           </div>
           <p className="text-sm text-blue-200 mt-4">
-            📞 Free 15-minute call • 🚀 Same-day response • ✓ No obligation
+            ✓ Upload or email one document • 🚀 Real sample gap analysis at no charge • ✓ No obligation
           </p>
         </div>
         {/* Decorative Elements */}
@@ -489,7 +494,7 @@ export default function Home() {
             </h2>
             <div className="w-24 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 mx-auto mb-6"></div>
             <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              Simple 3-step process to audit-ready compliance
+              Three steps to audit-ready findings — reviewed by a P.Eng before they reach you
             </p>
           </div>
 
@@ -512,17 +517,17 @@ export default function Home() {
             <div className="text-center">
               <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center text-2xl font-bold text-blue-600 mx-auto mb-4">1</div>
               <h3 className="text-xl font-semibold text-gray-900 mb-3">Send Your Documents</h3>
-              <p className="text-gray-600">Email your existing SOPs, handwritten notes, or Word docs. Any format works.</p>
+              <p className="text-gray-600">Email your quality manual, SOPs, or work instructions. Word, PDF, or scans — whatever you have.</p>
             </div>
             <div className="text-center">
               <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center text-2xl font-bold text-blue-600 mx-auto mb-4">2</div>
-              <h3 className="text-xl font-semibold text-gray-900 mb-3">AI Analysis</h3>
-              <p className="text-gray-600">Our AI scans for gaps, maps to ISO 9001 requirements, and identifies missing procedures.</p>
+              <h3 className="text-xl font-semibold text-gray-900 mb-3">P.Eng Reviews the Gaps</h3>
+              <p className="text-gray-600">We check your documentation against ISO 9001:2015 clause by clause. A licensed P.Eng reviews and validates every finding.</p>
             </div>
             <div className="text-center">
               <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center text-2xl font-bold text-blue-600 mx-auto mb-4">3</div>
-              <h3 className="text-xl font-semibold text-gray-900 mb-3">Get Audit-Ready SOPs</h3>
-              <p className="text-gray-600">Receive professional, P.Eng validated, audit-ready documentation in days, not months.</p>
+              <h3 className="text-xl font-semibold text-gray-900 mb-3">Get Audit-Ready Findings</h3>
+              <p className="text-gray-600">Receive a findings report mapped to specific clauses, with corrective action recommendations — in about 2 weeks, not 6 months.</p>
             </div>
           </div>
 
@@ -533,13 +538,14 @@ export default function Home() {
               <h3 className="text-2xl font-bold text-gray-900">Professional Engineer Validated</h3>
             </div>
             <p className="text-gray-700 text-lg max-w-3xl mx-auto">
-              Every gap analysis is reviewed by a licensed Professional Engineer (P.Eng) with ISO 9001
-              audit experience. You get AI speed with expert validation.
+              Every gap analysis is reviewed and signed off by a licensed Professional Engineer (P.Eng, APEGA)
+              with 12+ years in manufacturing quality assurance at building-materials and packaging plants.
+              Nothing is auto-generated and shipped.
             </p>
-            <div className="mt-6 flex items-center justify-center gap-8 text-sm text-gray-600">
-              <div>✓ P.Eng Certified</div>
-              <div>✓ ISO 9001 Expert</div>
-              <div>✓ 10+ Years Experience</div>
+            <div className="mt-6 flex flex-wrap items-center justify-center gap-8 text-sm text-gray-600">
+              <div>✓ Licensed P.Eng (APEGA)</div>
+              <div>✓ 12+ Years in Manufacturing QA</div>
+              <div>✓ Findings Mapped to ISO 9001:2015 Clauses</div>
             </div>
           </div>
 
@@ -556,99 +562,111 @@ export default function Home() {
           </div>
         </section>
 
-        {/* AI-Powered Features Section */}
+        {/* Why Trust Us Section */}
         <section className="mb-20">
           <div className="text-center mb-16">
             <h2 className="text-4xl font-bold text-gray-900 mb-4">
-              Beyond Traditional Tools
+              Why Trust Us
             </h2>
             <div className="w-24 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 mx-auto mb-6"></div>
             <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              Artificial intelligence meets personal service for truly smart compliance
+              A licensed engineer with real plant experience reviews your documentation. No black box.
             </p>
           </div>
 
-          <div className="grid md:grid-cols-3 gap-8 mb-12">
-            <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100 text-center">
-              <div className="text-5xl mb-6">🤖</div>
-              <h3 className="text-xl font-semibold text-gray-900 mb-4">Advanced AI Backend</h3>
+          <div className="grid md:grid-cols-2 gap-8 mb-12">
+            <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
+              <h3 className="text-xl font-semibold text-gray-900 mb-3">Licensed Professional Engineer</h3>
               <p className="text-gray-700">
-                Enterprise-grade artificial intelligence identifies patterns
-                and optimizes your documentation automatically.
+                Licensed Professional Engineer (P.Eng, APEGA) with 12+ years in manufacturing quality assurance.
+                Your findings are reviewed by an engineer, not a template.
               </p>
             </div>
 
-            <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100 text-center">
-              <div className="text-5xl mb-6">🔍</div>
-              <h3 className="text-xl font-semibold text-gray-900 mb-4">Intelligent Gap Detection</h3>
+            <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
+              <h3 className="text-xl font-semibold text-gray-900 mb-3">Real Plant Experience</h3>
               <p className="text-gray-700">
-                AI scans your SOPs and automatically finds missing procedures,
-                compliance gaps, and areas needing improvement.
+                Hands-on QMS and ISO experience in building materials manufacturing (IKO Industries)
+                and packaging manufacturing (WestRock). We have worked the shop floor, not just the standard.
               </p>
             </div>
 
-            <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100 text-center">
-              <div className="text-5xl mb-6">⚡</div>
-              <h3 className="text-xl font-semibold text-gray-900 mb-4">Smart Assistance</h3>
+            <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
+              <h3 className="text-xl font-semibold text-gray-900 mb-3">Audit-Ready Deliverables</h3>
               <p className="text-gray-700">
-                AI-powered suggestions help you create compliant documentation
-                faster than any traditional tool or manual process.
+                Findings are mapped to specific ISO 9001:2015 clauses, each with a corrective action
+                recommendation. You know exactly what to fix and where the standard requires it.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
+              <h3 className="text-xl font-semibold text-gray-900 mb-3">The Cost of Failing</h3>
+              <p className="text-gray-700">
+                A failed certification audit typically costs $8,000–$15,000 in wasted audit fees plus
+                3–6 months of delay. A pre-assessment costs a fraction of that. Find the gaps before the auditor does.
               </p>
             </div>
           </div>
+
+          {/* Single AI mention — framed as speed/cost, human-validated */}
+          <div className="bg-gray-50 rounded-2xl border border-gray-200 p-8 max-w-4xl mx-auto text-center">
+            <p className="text-gray-700 text-lg leading-relaxed">
+              <strong>How we work fast:</strong> we use modern analysis tooling to move quickly — but every finding
+              is reviewed and validated by a licensed P.Eng before it reaches you. Nothing is auto-generated and shipped.
+              Drafts are prepared for your review and validated by a P.Eng.
+            </p>
+          </div>
         </section>
 
-        {/* What We Do Section */}
+        {/* What You Get Section */}
         <section className="mb-20">
-          <div className="bg-gradient-to-r from-purple-50 to-blue-50 rounded-2xl shadow-xl p-8 md:p-12 border border-gray-100">
+          <div className="bg-gradient-to-r from-slate-50 to-blue-50 rounded-2xl shadow-xl p-8 md:p-12 border border-gray-100">
             <div className="grid md:grid-cols-2 gap-12 items-center">
               <div>
                 <h3 className="text-3xl font-bold text-gray-900 mb-6">
-                  AI Finds What Others Miss
+                  What You Get
                 </h3>
                 <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                  While traditional consultants rely on manual reviews, our AI-powered platform
-                  instantly analyzes your entire documentation ecosystem to identify gaps,
-                  inconsistencies, and compliance risks—then generates ISO 9001-compliant SOPs
-                  to fill those gaps.
+                  A clear picture of where your documentation stands against ISO 9001:2015 — and exactly
+                  what to fix before your audit. Every finding is drafted for your review and validated by a P.Eng.
                 </p>
                 <ul className="space-y-4">
                   <li className="flex items-start text-gray-700">
-                    <div className="w-6 h-6 bg-purple-500 rounded-full flex items-center justify-center mr-4 mt-1 flex-shrink-0">
+                    <div className="w-6 h-6 bg-blue-600 rounded-full flex items-center justify-center mr-4 mt-1 flex-shrink-0">
                       <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                       </svg>
                     </div>
                     <div>
-                      <strong>Automated Gap Analysis:</strong> AI scans every procedure for missing steps
+                      <strong>Clause-by-clause findings:</strong> each gap tied to the specific ISO 9001:2015 clause it affects
                     </div>
                   </li>
                   <li className="flex items-start text-gray-700">
-                    <div className="w-6 h-6 bg-purple-500 rounded-full flex items-center justify-center mr-4 mt-1 flex-shrink-0">
+                    <div className="w-6 h-6 bg-blue-600 rounded-full flex items-center justify-center mr-4 mt-1 flex-shrink-0">
                       <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                       </svg>
                     </div>
                     <div>
-                      <strong>Smart Compliance Mapping:</strong> Links SOPs to ISO requirements automatically
+                      <strong>Corrective action recommendations:</strong> what to change, in plain language, prioritized by audit risk
                     </div>
                   </li>
                   <li className="flex items-start text-gray-700">
-                    <div className="w-6 h-6 bg-purple-500 rounded-full flex items-center justify-center mr-4 mt-1 flex-shrink-0">
+                    <div className="w-6 h-6 bg-blue-600 rounded-full flex items-center justify-center mr-4 mt-1 flex-shrink-0">
                       <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                       </svg>
                     </div>
                     <div>
-                      <strong>Continuous Learning:</strong> Gets smarter with every document processed
+                      <strong>P.Eng sign-off:</strong> a licensed engineer reviews and validates every finding before you see it
                     </div>
                   </li>
                 </ul>
               </div>
-              <div className="bg-gradient-to-br from-purple-100 to-blue-100 rounded-xl p-8 text-center">
-                <div className="text-6xl mb-4">🧠</div>
-                <h4 className="text-xl font-semibold text-gray-900 mb-2">AI-Powered Intelligence</h4>
-                <p className="text-gray-600">Advanced algorithms that understand compliance like an expert auditor</p>
+              <div className="bg-gradient-to-br from-blue-100 to-indigo-100 rounded-xl p-8 text-center">
+                <div className="text-6xl mb-4">📋</div>
+                <h4 className="text-xl font-semibold text-gray-900 mb-2">Audit-Ready in About 2 Weeks</h4>
+                <p className="text-gray-600">A findings report you can hand to your team and act on before the auditor arrives</p>
               </div>
             </div>
           </div>
@@ -659,44 +677,44 @@ export default function Home() {
           <div className="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-2xl shadow-xl p-12 border border-blue-100">
             <div className="text-center mb-8">
               <h2 className="text-4xl font-bold text-gray-900 mb-4">
-                Built for Every Manufacturing Business
+                Built for Industrial Manufacturers
               </h2>
               <div className="w-24 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 mx-auto mb-6"></div>
               <p className="text-xl text-gray-700 max-w-3xl mx-auto leading-relaxed">
-                From small job shops to large production facilities, our AI-powered compliance platform serves
-                <strong> any kind of manufacturing industry</strong> seeking ISO 9001 certification.
+                We focus on small and mid-size general manufacturers — <strong>10 to 500 employees</strong> —
+                preparing for ISO 9001 certification, surveillance audits, or customer audits.
               </p>
             </div>
 
             <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
               <div className="bg-white rounded-xl p-6 shadow-lg">
                 <div className="text-4xl mb-4 text-center">🏭</div>
-                <h3 className="text-lg font-semibold text-gray-900 mb-2 text-center">All Industries Welcome</h3>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2 text-center">Industrial Manufacturing</h3>
                 <p className="text-gray-600 text-sm text-center">
-                  Whether you're in automotive, aerospace, electronics, food processing, consumer products, textiles, plastics, or any manufacturing sector
+                  Building materials, packaging, plastics, metal fabrication, and industrial products — the sectors we know firsthand
                 </p>
               </div>
 
               <div className="bg-white rounded-xl p-6 shadow-lg">
                 <div className="text-4xl mb-4 text-center">📊</div>
-                <h3 className="text-lg font-semibold text-gray-900 mb-2 text-center">Any Company Size</h3>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2 text-center">Small & Mid-Size</h3>
                 <p className="text-gray-600 text-sm text-center">
-                  From 5-person job shops to 500-employee facilities - our solution scales to your needs
+                  10 to 500 employees — the range where a full-time quality department is rare and outside help matters most
                 </p>
               </div>
 
               <div className="bg-white rounded-xl p-6 shadow-lg">
-                <div className="text-4xl mb-4 text-center">🌍</div>
-                <h3 className="text-lg font-semibold text-gray-900 mb-2 text-center">Global Reach</h3>
+                <div className="text-4xl mb-4 text-center">✅</div>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2 text-center">Any Audit Milestone</h3>
                 <p className="text-gray-600 text-sm text-center">
-                  Serving manufacturers worldwide - North America, Europe, Asia, and beyond
+                  First certification, annual surveillance audit, or a customer audit you can't afford to fail
                 </p>
               </div>
             </div>
 
             <div className="mt-10 text-center">
-              <p className="text-gray-700 text-lg font-semibold">
-                No matter what you make, we help you get audit-ready
+              <p className="text-gray-700 text-lg">
+                In a different manufacturing sector? We still work with you — just ask.
               </p>
             </div>
           </div>
@@ -707,50 +725,65 @@ export default function Home() {
           <div className="bg-gradient-to-r from-blue-900 to-indigo-900 rounded-2xl shadow-2xl p-8 md:p-12 text-white">
             <div className="text-center mb-12">
               <h2 className="text-4xl font-bold mb-4">
-                Professional ISO 9001 Compliance — Starting at $1,500
+                Start Small. Prove the Value First.
               </h2>
-              <p className="text-xl text-blue-100">
-                Save 70-85% vs traditional consultants | One-time packages or monthly subscriptions
+              <p className="text-xl text-blue-100 max-w-3xl mx-auto">
+                Try a Pilot Gap Analysis before committing to a full engagement. No retainer, no long contract.
               </p>
             </div>
-            
-            <div className="grid md:grid-cols-3 gap-8 mb-12">
-              {[
-                "AI processes any format: Word, PDF, handwritten notes",
-                "Intelligent gap detection and compliance mapping",
-                "Personal consultation combined with AI insights"
-              ].map((feature, index) => (
-                <div key={index} className="flex items-start">
-                  <div className="w-6 h-6 bg-orange-500 rounded-full flex items-center justify-center mr-4 mt-1 flex-shrink-0">
-                    <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                  </div>
-                  <p className="text-blue-100">{feature}</p>
-                </div>
-              ))}
+
+            <div className="grid md:grid-cols-2 gap-8 mb-12">
+              {/* Pilot */}
+              <div className="bg-white/10 border border-white/20 rounded-2xl p-8">
+                <h3 className="text-2xl font-bold mb-1">Pilot Gap Analysis</h3>
+                <div className="text-4xl font-bold mb-1">$597</div>
+                <p className="text-blue-200 mb-6 text-sm">Your quality manual or one process area</p>
+                <ul className="space-y-3 text-blue-100 text-sm">
+                  <li>✓ Gap analysis of one document set or process area</li>
+                  <li>✓ Findings mapped to ISO 9001:2015 clauses</li>
+                  <li>✓ Corrective action recommendations</li>
+                  <li>✓ Reviewed and signed off by a licensed P.Eng</li>
+                </ul>
+                <p className="text-blue-200 text-sm mt-6">A low-risk first step before the full engagement.</p>
+              </div>
+
+              {/* Full */}
+              <div className="bg-white text-gray-900 rounded-2xl p-8 shadow-xl">
+                <h3 className="text-2xl font-bold mb-1 text-blue-900">Full Gap Analysis</h3>
+                <div className="text-4xl font-bold mb-1">$1,500</div>
+                <p className="text-gray-600 mb-6 text-sm">Your full documentation set</p>
+                <ul className="space-y-3 text-gray-700 text-sm">
+                  <li>✓ Full documentation gap analysis</li>
+                  <li>✓ Clause-by-clause findings report</li>
+                  <li>✓ Corrective action roadmap</li>
+                  <li>✓ One review call to walk through the findings</li>
+                  <li>✓ Every finding validated by a licensed P.Eng</li>
+                </ul>
+                <p className="text-gray-600 text-sm mt-6">Audit-ready findings in about 2 weeks.</p>
+              </div>
             </div>
-            
+
             <div className="text-center">
-              <p className="text-xl mb-8 text-blue-100">
-                <strong>Transparent pricing. No hidden fees. Book a free call or view detailed pricing.</strong>
+              <p className="text-lg mb-8 text-blue-100 max-w-3xl mx-auto">
+                A failed certification audit typically costs $8,000–$15,000 plus 3–6 months of delay.
+                A pre-assessment costs a fraction of that.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <Link
-                  href="/pricing"
-                  className="inline-block bg-gradient-to-r from-orange-500 to-red-500 text-white px-10 py-4 rounded-full text-lg font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 transition-all duration-300"
-                >
-                  📋 View Detailed Pricing
-                </Link>
                 <button
                   onClick={() => setIsModalOpen(true)}
+                  className="inline-block bg-gradient-to-r from-orange-500 to-red-500 text-white px-10 py-4 rounded-full text-lg font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 transition-all duration-300"
+                >
+                  Get a free sample gap analysis
+                </button>
+                <Link
+                  href="/pricing"
                   className="inline-block bg-white text-blue-900 px-10 py-4 rounded-full text-lg font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 transition-all duration-300"
                 >
-                  Book Free Call
-                </button>
+                  View Detailed Pricing
+                </Link>
               </div>
               <p className="text-sm text-blue-200 mt-4">
-                📞 Free 15-minute call • 🚀 Same-day response • ✓ No obligation
+                ✓ Send one document • 🚀 24-hour response • ✓ No obligation
               </p>
             </div>
           </div>
@@ -766,7 +799,7 @@ export default function Home() {
               <div className="space-y-2 text-sm">
                 <p>📧 <a href="mailto:info@auditsready.com" className="hover:text-white transition-colors">info@auditsready.com</a></p>
                 <p><PhoneDisplay /></p>
-                <p>🌎 Serving North America & Beyond</p>
+                <p>🌎 Serving manufacturers in North America & worldwide</p>
               </div>
             </div>
 
@@ -774,10 +807,10 @@ export default function Home() {
             <div>
               <h3 className="text-white font-semibold mb-4">Services</h3>
               <ul className="space-y-2 text-sm">
-                <li>AI-Powered Gap Analysis</li>
-                <li>SOP Document Conversion</li>
-                <li>Audit Preparation</li>
-                <li>P.Eng Validated Consulting</li>
+                <li>ISO 9001 Gap Analysis</li>
+                <li>Pre-Assessment & Audit Readiness</li>
+                <li>Corrective Action Roadmaps</li>
+                <li>P.Eng-Validated Findings</li>
               </ul>
             </div>
 
@@ -808,7 +841,7 @@ export default function Home() {
               &copy; {new Date().getFullYear()} AuditsReady. All rights reserved.
             </p>
             <p className="text-xs text-gray-500">
-              Professional Engineer (P.Eng) Validated | Where artificial intelligence meets manufacturing excellence.
+              ISO 9001 gap analysis reviewed and signed off by a licensed Professional Engineer (P.Eng).
             </p>
           </div>
         </div>

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -74,7 +74,7 @@ function ContactFormModal({ isOpen, onClose }) {
       <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
         <div className="p-8">
           <div className="flex justify-between items-center mb-6">
-            <h2 className="text-3xl font-bold text-gray-900">Get Custom Quote</h2>
+            <h2 className="text-3xl font-bold text-gray-900">Tell Us About Your Project</h2>
             <button
               onClick={onClose}
               className="text-gray-400 hover:text-gray-600 text-3xl leading-none"
@@ -84,7 +84,8 @@ function ContactFormModal({ isOpen, onClose }) {
           </div>
 
           <p className="text-gray-600 mb-6">
-            Tell us about your needs and we'll provide a customized quote within 24 hours.
+            Tell us what you're preparing for and roughly how many documents you have. We'll reply within 24 hours.
+            Prefer to see it first? Send one document for a free sample gap analysis.
           </p>
 
           <form onSubmit={handleSubmit}>
@@ -161,7 +162,7 @@ function ContactFormModal({ isOpen, onClose }) {
 
             {submitStatus === 'success' && (
               <div className="mt-4 bg-green-50 border border-green-200 rounded-lg p-4">
-                <p className="text-green-800 font-semibold">✓ Thank you! We'll send you a custom quote within 24 hours.</p>
+                <p className="text-green-800 font-semibold">✓ Thank you! We'll reply within 24 hours. If you sent a document, we'll return a sample gap analysis at no charge.</p>
               </div>
             )}
 
@@ -178,7 +179,7 @@ function ContactFormModal({ isOpen, onClose }) {
                 disabled={isSubmitting}
                 className="flex-1 bg-gradient-to-r from-orange-500 to-red-500 text-white px-8 py-4 rounded-full text-lg font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 transition-all duration-300 disabled:opacity-50"
               >
-                {isSubmitting ? 'Submitting...' : 'Get Custom Quote'}
+                {isSubmitting ? 'Submitting...' : 'Send Request'}
               </button>
               <button
                 type="button"
@@ -203,24 +204,24 @@ export default function Pricing() {
       <ContactFormModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
 
       <Head>
-        <title>Pricing - AI-Powered ISO 9001 Compliance | AuditsReady</title>
-        <meta name="description" content="AuditsReady pricing: 70-85% savings vs traditional ISO 9001 consultants. One-time packages from $1,500 or monthly subscriptions from $99. AI-powered gap analysis and SOP generation." />
+        <title>ISO 9001 Gap Analysis Pricing | Pilot $597, Full $1,500 | P.Eng-Validated | AuditsReady</title>
+        <meta name="description" content="ISO 9001 gap analysis for small and mid-size manufacturers. Pilot from $597, full engagement $1,500. Findings mapped to ISO 9001:2015 clauses and signed off by a licensed P.Eng. A fraction of consultant cost." />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="robots" content="index, follow" />
-        <meta name="keywords" content="ISO 9001 pricing, ISO consultant cost, gap analysis price, SOP compliance cost, ISO certification pricing, affordable ISO 9001" />
+        <meta name="keywords" content="ISO 9001 gap analysis pricing, ISO 9001 pre-assessment cost, ISO 9001 for small manufacturers, ISO consultant cost, P.Eng validated gap analysis, affordable ISO 9001" />
         <link rel="canonical" href="https://auditsready.com/pricing" />
 
         {/* OpenGraph */}
-        <meta property="og:title" content="Pricing - AI-Powered ISO 9001 Compliance | AuditsReady" />
-        <meta property="og:description" content="Save 70-85% vs traditional consultants. AI-powered ISO 9001 gap analysis and SOP generation from $1,500." />
+        <meta property="og:title" content="ISO 9001 Gap Analysis Pricing | Pilot $597, Full $1,500 | P.Eng-Validated" />
+        <meta property="og:description" content="ISO 9001 gap analysis for small and mid-size manufacturers. Pilot from $597, full engagement $1,500. Signed off by a licensed P.Eng. A fraction of consultant cost." />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://auditsready.com/pricing" />
         <meta property="og:image" content="https://auditsready.com/iso-9001-ai-powered-compliance-auditsready-logo.png" />
 
         {/* Twitter */}
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Pricing - AI-Powered ISO 9001 Compliance" />
-        <meta name="twitter:description" content="70-85% savings vs traditional ISO consultants. AI-powered compliance from $1,500." />
+        <meta name="twitter:title" content="ISO 9001 Gap Analysis Pricing | Pilot $597, Full $1,500" />
+        <meta name="twitter:description" content="ISO 9001 gap analysis for small and mid-size manufacturers. Signed off by a licensed P.Eng. A fraction of consultant cost." />
         <meta name="twitter:image" content="https://auditsready.com/iso-9001-ai-powered-compliance-auditsready-logo.png" />
 
         {/* Favicon */}
@@ -235,8 +236,8 @@ export default function Pricing() {
             __html: JSON.stringify({
               "@context": "https://schema.org",
               "@type": "Product",
-              "name": "AuditsReady ISO 9001 Compliance Service",
-              "description": "AI-powered ISO 9001 gap analysis and SOP generation service",
+              "name": "AuditsReady ISO 9001 Gap Analysis",
+              "description": "P.Eng-validated ISO 9001 gap analysis for small and mid-size manufacturers. Findings mapped to specific ISO 9001:2015 clauses with corrective action recommendations.",
               "brand": {
                 "@type": "Brand",
                 "name": "AuditsReady"
@@ -244,24 +245,17 @@ export default function Pricing() {
               "offers": [
                 {
                   "@type": "Offer",
-                  "name": "Basic Package",
+                  "name": "Pilot Gap Analysis",
+                  "price": "597",
+                  "priceCurrency": "USD",
+                  "description": "Gap analysis of your quality manual or one process area, mapped to ISO 9001:2015 clauses and signed off by a licensed P.Eng. A low-risk first step."
+                },
+                {
+                  "@type": "Offer",
+                  "name": "Full Gap Analysis",
                   "price": "1500",
                   "priceCurrency": "USD",
-                  "description": "25 documents digitization with ISO 9001 formatting"
-                },
-                {
-                  "@type": "Offer",
-                  "name": "Professional Package",
-                  "price": "2500",
-                  "priceCurrency": "USD",
-                  "description": "25 documents with detailed gap analysis and compliance mapping"
-                },
-                {
-                  "@type": "Offer",
-                  "name": "Premium Package",
-                  "price": "4500",
-                  "priceCurrency": "USD",
-                  "description": "25 documents with AI-generated fixes and P.Eng verification"
+                  "description": "Full documentation gap analysis, clause-by-clause findings report, corrective action roadmap, and one review call. Every finding validated by a licensed P.Eng."
                 }
               ]
             })
@@ -300,10 +294,10 @@ export default function Pricing() {
             Transparent Pricing
           </h1>
           <p className="text-2xl md:text-3xl font-light mb-8 text-blue-100">
-            Save 70-85% vs Traditional ISO Consultants
+            Pilot from $597. Full gap analysis $1,500.
           </p>
           <p className="text-xl max-w-3xl mx-auto text-blue-100">
-            One-time packages or flexible monthly subscriptions. No hidden fees. No surprises.
+            One-time engagements. No retainer, no long contract. Every finding signed off by a licensed P.Eng.
           </p>
         </div>
       </section>
@@ -313,109 +307,105 @@ export default function Pricing() {
         {/* Value Proposition */}
         <div className="bg-gradient-to-r from-blue-900 to-indigo-900 text-white rounded-2xl p-12 mb-16 text-center">
           <h2 className="text-4xl font-bold mb-6">
-            AI-Powered Compliance at 1/10th the Cost
+            Consultant-Quality Findings, a Fraction of the Cost
           </h2>
           <p className="text-xl text-blue-100 max-w-4xl mx-auto leading-relaxed">
-            Our AI analyzes your documentation, identifies gaps, and generates ISO 9001-compliant SOPs — all validated by a licensed Professional Engineer (P.Eng). Get consultant-quality results without consultant-level prices.
+            We check your documentation against ISO 9001:2015 clause by clause and tell you exactly what to fix before your audit. Every finding is reviewed and signed off by a licensed Professional Engineer (P.Eng) with 12+ years in manufacturing quality. Nothing is auto-generated and shipped.
           </p>
         </div>
 
-        {/* One-Time Packages */}
+        {/* Engagements */}
         <section className="mb-20">
           <div className="text-center mb-12">
             <h2 className="text-4xl font-bold text-gray-900 mb-4">
-              One-Time Packages
+              Two Ways to Start
             </h2>
             <p className="text-xl text-gray-600">
-              Perfect for certification preparation or one-time document reviews
+              Try a pilot first, or go straight to the full gap analysis. One-time engagements, no retainer.
             </p>
           </div>
 
-          <div className="grid md:grid-cols-3 gap-8 mb-12">
-            {/* Basic */}
+          <div className="grid md:grid-cols-2 gap-8 mb-12 max-w-4xl mx-auto">
+            {/* Pilot */}
             <div className="bg-white rounded-2xl shadow-xl p-8 border-2 border-gray-200 hover:shadow-2xl transition-all duration-300">
               <div className="text-center mb-6">
-                <h3 className="text-2xl font-bold text-blue-900 mb-2">Basic</h3>
-                <div className="text-5xl font-bold text-gray-900 mb-2">$1,500</div>
-                <p className="text-gray-600">25 documents ($60/doc)</p>
+                <h3 className="text-2xl font-bold text-blue-900 mb-2">Pilot Gap Analysis</h3>
+                <div className="text-5xl font-bold text-gray-900 mb-2">$597</div>
+                <p className="text-gray-600">Your quality manual or one process area</p>
               </div>
 
               <ul className="space-y-4 mb-8">
                 <li className="flex items-start">
                   <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span>Document digitization</span>
+                  <span>Gap analysis of one document set or process area</span>
                 </li>
                 <li className="flex items-start">
                   <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span>ISO 9001 formatted SOPs</span>
+                  <span>Findings mapped to ISO 9001:2015 clauses</span>
                 </li>
                 <li className="flex items-start">
                   <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span>Quality validation</span>
+                  <span>Corrective action recommendations</span>
                 </li>
                 <li className="flex items-start">
                   <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span>Editable Word documents</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span>Basic confidence scoring</span>
+                  <span>Reviewed and signed off by a licensed P.Eng</span>
                 </li>
               </ul>
 
               <p className="text-sm text-gray-600 mb-6">
-                <strong>Best for:</strong> Companies with existing ISO knowledge who need digitization
+                <strong>Best for:</strong> Seeing the quality of our work before a full engagement
               </p>
 
               <button
                 onClick={() => setIsModalOpen(true)}
                 className="w-full bg-blue-900 text-white py-4 rounded-full font-semibold hover:bg-blue-800 transition-colors"
               >
-                Get Started
+                Start With a Pilot
               </button>
             </div>
 
-            {/* Professional */}
-            <div className="bg-white rounded-2xl shadow-2xl p-8 border-4 border-blue-900 relative transform scale-105">
+            {/* Full */}
+            <div className="bg-white rounded-2xl shadow-2xl p-8 border-4 border-blue-900 relative transform md:scale-105">
               <div className="absolute -top-4 left-1/2 transform -translate-x-1/2 bg-gradient-to-r from-orange-500 to-red-500 text-white px-6 py-2 rounded-full text-sm font-bold">
                 MOST POPULAR
               </div>
 
               <div className="text-center mb-6 mt-4">
-                <h3 className="text-2xl font-bold text-blue-900 mb-2">Professional</h3>
-                <div className="text-5xl font-bold text-gray-900 mb-2">$2,500</div>
-                <p className="text-gray-600">25 documents ($100/doc)</p>
+                <h3 className="text-2xl font-bold text-blue-900 mb-2">Full Gap Analysis</h3>
+                <div className="text-5xl font-bold text-gray-900 mb-2">$1,500</div>
+                <p className="text-gray-600">Your full documentation set</p>
               </div>
 
               <ul className="space-y-4 mb-8">
                 <li className="flex items-start">
                   <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span><strong>Everything in Basic</strong></span>
+                  <span><strong>Full documentation gap analysis</strong></span>
                 </li>
                 <li className="flex items-start">
                   <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span><strong>Detailed gap analysis</strong></span>
+                  <span>Clause-by-clause findings report</span>
                 </li>
                 <li className="flex items-start">
                   <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span>Clause-by-clause ISO 9001 mapping</span>
+                  <span>Corrective action roadmap, prioritized by audit risk</span>
                 </li>
                 <li className="flex items-start">
                   <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span>Gap severity levels</span>
+                  <span>One review call to walk through the findings</span>
                 </li>
                 <li className="flex items-start">
                   <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span>Comprehensive gap report</span>
+                  <span><strong>Every finding validated by a licensed P.Eng</strong></span>
                 </li>
                 <li className="flex items-start">
                   <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span>Priority action plan</span>
+                  <span>Audit-ready findings in about 2 weeks</span>
                 </li>
               </ul>
 
               <p className="text-sm text-gray-600 mb-6">
-                <strong>Best for:</strong> Companies preparing for certification who need to know exactly what's missing
+                <strong>Best for:</strong> Manufacturers preparing for certification, surveillance, or a customer audit
               </p>
 
               <button
@@ -425,301 +415,57 @@ export default function Pricing() {
                 Get Started
               </button>
             </div>
-
-            {/* Premium */}
-            <div className="bg-white rounded-2xl shadow-xl p-8 border-2 border-gray-200 hover:shadow-2xl transition-all duration-300">
-              <div className="text-center mb-6">
-                <h3 className="text-2xl font-bold text-blue-900 mb-2">Premium</h3>
-                <div className="text-5xl font-bold text-gray-900 mb-2">$4,500</div>
-                <p className="text-gray-600">25 documents ($180/doc)</p>
-              </div>
-
-              <ul className="space-y-4 mb-8">
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span><strong>Everything in Professional</strong></span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span><strong>AI-generated gap fixes</strong></span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span>Surgical insertions (preserves content)</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span>Fixed SOP documents</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span><strong>P.Eng verification</strong></span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3 text-xl">✓</span>
-                  <span>Compliance certification letter</span>
-                </li>
-              </ul>
-
-              <p className="text-sm text-gray-600 mb-6">
-                <strong>Best for:</strong> Companies wanting "done for you" with P.Eng validation
-              </p>
-
-              <button
-                onClick={() => setIsModalOpen(true)}
-                className="w-full bg-blue-900 text-white py-4 rounded-full font-semibold hover:bg-blue-800 transition-colors"
-              >
-                Get Started
-              </button>
-            </div>
           </div>
+
+          <p className="text-center text-gray-600 max-w-2xl mx-auto">
+            Not sure yet? Send us one document — your quality manual or a single SOP — and we'll return a real
+            sample gap analysis at no charge, usually within 24 hours.
+          </p>
         </section>
 
         {/* Cost Comparison */}
         <section className="mb-20">
           <div className="bg-gradient-to-r from-amber-50 to-orange-50 rounded-2xl p-12 border-l-8 border-orange-500">
             <h2 className="text-4xl font-bold text-gray-900 mb-8 text-center">
-              Your Savings vs Traditional Consultants
+              What Gap Analysis Usually Costs
             </h2>
 
             <div className="overflow-x-auto">
               <table className="w-full bg-white rounded-xl shadow-lg">
                 <thead>
                   <tr className="bg-blue-900 text-white">
-                    <th className="py-4 px-6 text-left font-bold">Service</th>
-                    <th className="py-4 px-6 text-left font-bold">Traditional Consultant</th>
-                    <th className="py-4 px-6 text-left font-bold">AuditsReady</th>
-                    <th className="py-4 px-6 text-left font-bold">Your Savings</th>
+                    <th className="py-4 px-6 text-left font-bold">Approach</th>
+                    <th className="py-4 px-6 text-left font-bold">Typical Cost</th>
+                    <th className="py-4 px-6 text-left font-bold">Turnaround</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr className="border-b">
-                    <td className="py-4 px-6 font-semibold">Document Digitization (25 docs)</td>
-                    <td className="py-4 px-6">$5,000 - $8,000</td>
-                    <td className="py-4 px-6 text-blue-900 font-bold">$1,500</td>
-                    <td className="py-4 px-6 text-green-600 font-bold">$3,500 - $6,500 (70-81%)</td>
+                    <td className="py-4 px-6 font-semibold">Traditional consultant gap analysis</td>
+                    <td className="py-4 px-6">$5,000 - $15,000</td>
+                    <td className="py-4 px-6">4 - 8 weeks</td>
                   </tr>
                   <tr className="border-b bg-blue-50">
-                    <td className="py-4 px-6 font-semibold">Gap Analysis + Digitization</td>
-                    <td className="py-4 px-6">$10,000 - $15,000</td>
-                    <td className="py-4 px-6 text-blue-900 font-bold">$2,500</td>
-                    <td className="py-4 px-6 text-green-600 font-bold">$7,500 - $12,500 (75-83%)</td>
-                  </tr>
-                  <tr className="border-b">
-                    <td className="py-4 px-6 font-semibold">Gap Analysis + Remediation</td>
-                    <td className="py-4 px-6">$15,000 - $30,000</td>
-                    <td className="py-4 px-6 text-blue-900 font-bold">$4,500</td>
-                    <td className="py-4 px-6 text-green-600 font-bold">$10,500 - $25,500 (70-85%)</td>
+                    <td className="py-4 px-6 font-semibold">AuditsReady Full Gap Analysis (P.Eng-validated)</td>
+                    <td className="py-4 px-6 text-blue-900 font-bold">$1,500</td>
+                    <td className="py-4 px-6">~2 weeks</td>
                   </tr>
                   <tr className="bg-green-50">
-                    <td className="py-4 px-6 font-semibold">Full Certification Support (Annual)</td>
-                    <td className="py-4 px-6">$20,000 - $50,000</td>
-                    <td className="py-4 px-6 text-blue-900 font-bold">$8,088<br/><span className="text-sm text-gray-600">(Package + Subscription)</span></td>
-                    <td className="py-4 px-6 text-green-600 font-bold">$11,912 - $41,912 (60-84%)</td>
+                    <td className="py-4 px-6 font-semibold">AuditsReady Pilot Gap Analysis</td>
+                    <td className="py-4 px-6 text-blue-900 font-bold">$597</td>
+                    <td className="py-4 px-6">~1 week</td>
                   </tr>
                 </tbody>
               </table>
             </div>
 
             <div className="mt-12 bg-white rounded-xl p-8 text-center shadow-lg">
-              <h3 className="text-3xl font-bold text-green-600 mb-4">Average Customer Savings</h3>
-              <p className="text-5xl font-bold text-green-600 mb-4">$10,000 - $25,000</p>
-              <p className="text-gray-600 text-lg">Per engagement compared to traditional consulting</p>
-            </div>
-          </div>
-        </section>
-
-        {/* Monthly Subscriptions */}
-        <section className="mb-20">
-          <div className="text-center mb-12">
-            <h2 className="text-4xl font-bold text-gray-900 mb-4">
-              Monthly Subscription Plans
-            </h2>
-            <p className="text-xl text-gray-600">
-              Ongoing compliance support with document management and continuous analysis
-            </p>
-          </div>
-
-          <div className="grid md:grid-cols-3 gap-8">
-            {/* Basic Subscription */}
-            <div className="bg-white rounded-2xl shadow-xl p-8 border-2 border-gray-200">
-              <h3 className="text-2xl font-bold text-blue-900 mb-4 text-center">Basic</h3>
-              <div className="text-center mb-8">
-                <span className="text-5xl font-bold text-gray-900">$99</span>
-                <span className="text-gray-600">/month</span>
-              </div>
-
-              <ul className="space-y-3 mb-8">
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span>50 conversions/month</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span>500 documents storage</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span>Version control</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span>Basic support</span>
-                </li>
-              </ul>
-
-              <button
-                onClick={() => setIsModalOpen(true)}
-                className="w-full bg-blue-900 text-white py-3 rounded-full font-semibold hover:bg-blue-800 transition-colors"
-              >
-                Start Free Trial
-              </button>
-            </div>
-
-            {/* Professional Subscription */}
-            <div className="bg-white rounded-2xl shadow-2xl p-8 border-4 border-blue-900 transform scale-105">
-              <div className="bg-blue-900 text-white text-center py-2 rounded-lg mb-4 font-bold">
-                RECOMMENDED
-              </div>
-              <h3 className="text-2xl font-bold text-blue-900 mb-4 text-center">Professional</h3>
-              <div className="text-center mb-8">
-                <span className="text-5xl font-bold text-gray-900">$299</span>
-                <span className="text-gray-600">/month</span>
-              </div>
-
-              <ul className="space-y-3 mb-8">
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span>500 conversions/month</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span><strong>Gap analysis included</strong></span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span>5,000 documents storage</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span>Priority support</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span>API access</span>
-                </li>
-              </ul>
-
-              <button
-                onClick={() => setIsModalOpen(true)}
-                className="w-full bg-gradient-to-r from-orange-500 to-red-500 text-white py-3 rounded-full font-semibold shadow-lg hover:shadow-xl transition-all"
-              >
-                Start Free Trial
-              </button>
-            </div>
-
-            {/* Enterprise Subscription */}
-            <div className="bg-white rounded-2xl shadow-xl p-8 border-2 border-gray-200">
-              <h3 className="text-2xl font-bold text-blue-900 mb-4 text-center">Enterprise</h3>
-              <div className="text-center mb-8">
-                <span className="text-5xl font-bold text-gray-900">$999</span>
-                <span className="text-gray-600">/month</span>
-              </div>
-
-              <ul className="space-y-3 mb-8">
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span>Unlimited conversions</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span><strong>Multi-standard support</strong></span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span>Unlimited storage</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span>Multi-user access (10 users)</span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-green-500 mr-3">✓</span>
-                  <span>Dedicated account manager</span>
-                </li>
-              </ul>
-
-              <button
-                onClick={() => setIsModalOpen(true)}
-                className="w-full bg-blue-900 text-white py-3 rounded-full font-semibold hover:bg-blue-800 transition-colors"
-              >
-                Contact Sales
-              </button>
-            </div>
-          </div>
-        </section>
-
-        {/* ROI Example */}
-        <section className="mb-20">
-          <div className="bg-gradient-to-r from-green-50 to-emerald-50 rounded-2xl p-12 border-l-8 border-green-500">
-            <h2 className="text-4xl font-bold text-gray-900 mb-8 text-center">
-              Real-World Example: Small Manufacturer
-            </h2>
-
-            <div className="grid md:grid-cols-2 gap-12">
-              <div>
-                <h3 className="text-2xl font-bold text-gray-900 mb-6">Traditional Consultant Route</h3>
-                <div className="bg-white rounded-xl p-6 shadow-lg">
-                  <div className="space-y-4">
-                    <div className="flex justify-between pb-3 border-b">
-                      <span>Gap Analysis</span>
-                      <span className="font-bold">$10,000</span>
-                    </div>
-                    <div className="flex justify-between pb-3 border-b">
-                      <span>Document Remediation</span>
-                      <span className="font-bold">$15,000</span>
-                    </div>
-                    <div className="flex justify-between pb-3 border-b">
-                      <span>Annual Support</span>
-                      <span className="font-bold">$5,000</span>
-                    </div>
-                    <div className="flex justify-between pt-3 bg-red-50 p-4 rounded-lg">
-                      <span className="font-bold">First Year Total</span>
-                      <span className="font-bold text-red-600 text-2xl">$30,000</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div>
-                <h3 className="text-2xl font-bold text-gray-900 mb-6">AuditsReady Route</h3>
-                <div className="bg-white rounded-xl p-6 shadow-lg">
-                  <div className="space-y-4">
-                    <div className="flex justify-between pb-3 border-b">
-                      <span>Premium Package (25 docs)</span>
-                      <span className="font-bold">$4,500</span>
-                    </div>
-                    <div className="flex justify-between pb-3 border-b">
-                      <span>Professional Subscription (12 months)</span>
-                      <span className="font-bold">$3,588</span>
-                    </div>
-                    <div className="flex justify-between pb-3 border-b">
-                      <span>&nbsp;</span>
-                      <span>&nbsp;</span>
-                    </div>
-                    <div className="flex justify-between pt-3 bg-green-50 p-4 rounded-lg">
-                      <span className="font-bold">First Year Total</span>
-                      <span className="font-bold text-green-600 text-2xl">$8,088</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="mt-12 bg-white rounded-xl p-8 text-center shadow-lg">
-              <h3 className="text-3xl font-bold text-green-600 mb-3">Total First Year Savings</h3>
-              <p className="text-6xl font-bold text-green-600 mb-4">$21,912</p>
-              <p className="text-gray-600 text-xl">That's a 73% cost reduction with the same compliance results</p>
+              <h3 className="text-3xl font-bold text-gray-900 mb-4">The Real Number to Watch</h3>
+              <p className="text-gray-700 text-lg max-w-3xl mx-auto">
+                A failed certification audit typically costs <strong>$8,000&ndash;$15,000</strong> in wasted audit fees
+                plus <strong>3&ndash;6 months</strong> of delay. A pre-assessment costs a fraction of that. Find the gaps
+                before the auditor does.
+              </p>
             </div>
           </div>
         </section>
@@ -733,27 +479,27 @@ export default function Pricing() {
 
             <div className="grid md:grid-cols-4 gap-8">
               <div className="text-center">
-                <div className="text-6xl mb-4">⚡</div>
-                <h3 className="text-xl font-bold text-blue-900 mb-3">Fast</h3>
-                <p className="text-gray-600">5 minutes per document vs weeks with consultants</p>
+                <div className="text-6xl mb-4">🛡️</div>
+                <h3 className="text-xl font-bold text-blue-900 mb-3">P.Eng-Validated</h3>
+                <p className="text-gray-600">Every finding reviewed and signed off by a licensed Professional Engineer</p>
               </div>
 
               <div className="text-center">
-                <div className="text-6xl mb-4">💰</div>
-                <h3 className="text-xl font-bold text-blue-900 mb-3">Affordable</h3>
-                <p className="text-gray-600">1/10th the cost of traditional consulting</p>
+                <div className="text-6xl mb-4">🏭</div>
+                <h3 className="text-xl font-bold text-blue-900 mb-3">Plant Experience</h3>
+                <p className="text-gray-600">12+ years in manufacturing quality at building-materials and packaging plants</p>
               </div>
 
               <div className="text-center">
                 <div className="text-6xl mb-4">🎯</div>
-                <h3 className="text-xl font-bold text-blue-900 mb-3">Accurate</h3>
-                <p className="text-gray-600">P.Eng-verified compliance analysis</p>
+                <h3 className="text-xl font-bold text-blue-900 mb-3">Clause-Mapped</h3>
+                <p className="text-gray-600">Findings tied to specific ISO 9001:2015 clauses with corrective actions</p>
               </div>
 
               <div className="text-center">
-                <div className="text-6xl mb-4">📋</div>
-                <h3 className="text-xl font-bold text-blue-900 mb-3">Comprehensive</h3>
-                <p className="text-gray-600">Clause-by-clause ISO 9001:2015 mapping</p>
+                <div className="text-6xl mb-4">💰</div>
+                <h3 className="text-xl font-bold text-blue-900 mb-3">A Fraction of the Cost</h3>
+                <p className="text-gray-600">Far less than a traditional consultant, and far less than a failed audit</p>
               </div>
             </div>
           </div>
@@ -764,14 +510,14 @@ export default function Pricing() {
           <div className="bg-gradient-to-r from-blue-900 to-indigo-900 text-white rounded-2xl p-12">
             <h2 className="text-4xl font-bold mb-6">Ready to Get Started?</h2>
             <p className="text-xl text-blue-100 mb-8 max-w-3xl mx-auto">
-              Contact us for a free consultation and see how much you can save with AI-powered compliance
+              Send us one document for a free sample gap analysis, or start with a $597 pilot. Every finding is validated by a licensed P.Eng.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <button
                 onClick={() => setIsModalOpen(true)}
                 className="inline-block bg-gradient-to-r from-orange-500 to-red-500 text-white px-10 py-4 rounded-full text-lg font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 transition-all duration-300"
               >
-                Get Custom Quote
+                Get a Free Sample Gap Analysis
               </button>
               <Link
                 href="/blog/iso-9001-checklist"
@@ -798,7 +544,7 @@ export default function Pricing() {
                 className="mb-4 opacity-80"
               />
               <p className="text-sm text-gray-400">
-                AI-Powered ISO 9001 Compliance for Manufacturers Worldwide
+                P.Eng-Validated ISO 9001 Gap Analysis for Small & Mid-Size Manufacturers
               </p>
             </div>
 
@@ -807,17 +553,17 @@ export default function Pricing() {
               <div className="space-y-2 text-sm">
                 <p>📧 <a href="mailto:info@auditsready.com" className="hover:text-white transition-colors">info@auditsready.com</a></p>
                 <p><PhoneDisplay /></p>
-                <p>🌎 Serving Worldwide</p>
+                <p>🌎 Serving manufacturers in North America & worldwide</p>
               </div>
             </div>
 
             <div>
               <h3 className="text-white font-semibold mb-4">Services</h3>
               <ul className="space-y-2 text-sm">
-                <li>AI-Powered Gap Analysis</li>
-                <li>SOP Document Generation</li>
-                <li>Audit Preparation</li>
-                <li>P.Eng Validated Consulting</li>
+                <li>ISO 9001 Gap Analysis</li>
+                <li>Pre-Assessment & Audit Readiness</li>
+                <li>Corrective Action Roadmaps</li>
+                <li>P.Eng-Validated Findings</li>
               </ul>
             </div>
 
@@ -836,7 +582,7 @@ export default function Pricing() {
               &copy; {new Date().getFullYear()} AuditsReady. All rights reserved.
             </p>
             <p className="text-xs text-gray-500">
-              Professional Engineer (P.Eng) Validated | AI-Powered ISO 9001 Compliance
+              ISO 9001 gap analysis reviewed and signed off by a licensed Professional Engineer (P.Eng).
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Why

Current positioning — "AI-Powered ISO 9001 Gap Analysis | Any Manufacturing Industry" — is failing to convert. Two problems:

1. **"Any industry, any size, worldwide" is no positioning.** Buyers don't trust generalists with compliance.
2. **"AI-powered" as the headline scares the buyer.** The typical buyer is a plant/quality manager at a small/mid-size manufacturer who fears AI-generated compliance documents failing a real audit. AI is the *how*, not the headline.

This PR repositions the site around a **beachhead: small & mid-size general industrial manufacturers** (building materials, packaging, plastics, metal fabrication, industrial products; 10–500 employees), led by **licensed P.Eng validation**, with AI demoted to a single speed/cost mention.

## Changes

**`pages/index.js` (homepage)**
- Hero: **"Pass your ISO 9001 audit — without the \$20K consultant."** + P.Eng trust pill + P.Eng/12-yr subheadline + beachhead line
- Primary CTA: "Get a free gap analysis of your quality manual or one SOP"; secondary: "Book a 15-minute call"
- New **"Why Trust Us"** credibility section (proof points + \$8K–\$15K failed-audit framing) and **"What You Get"** deliverables
- Generalist section → **"Built for Industrial Manufacturers"** (beachhead + "other sectors? just ask")
- **Pilot \$597 → Full \$1,500** offer
- Title/meta/OG/Twitter + all JSON-LD rewritten; **removed fabricated 5.0 aggregateRating**

**`pages/pricing.js`**
- Replaced per-25-document packages (\$1,500/\$2,500/\$4,500) **and** monthly SaaS subscriptions (\$99/\$299/\$999) with **Pilot \$597 → Full \$1,500**
- Rebuilt cost-comparison table; removed fabricated ROI numbers
- De-AI'd title/meta/JSON-LD/copy/footer; dropped "AI generates SOPs" claim

**`pages/faq.js`**
- Reconciled turnaround to **~2 weeks** (was "48-72 hours")
- Reframed AI answers (tooling is the *how*; P.Eng validates every finding; drafts are for review, never auto-shipped)
- Updated pricing refs to \$597/\$1,500; de-AI'd meta + bottom CTA

**`CLAUDE.md`**
- Overview, target market, SEO, landing-page sections, positioning guardrails updated
- Added 2026-07-05 Recent Updates entry; bumped footers

## Turnaround standard
Free single-document sample in ~24 hours; full engagement in ~2 weeks.

## Tone rules applied
Written for a skeptical quality manager, not a tech buyer. No startup language. No invented testimonials, client names, or certifications. Only the proof points provided (P.Eng/APEGA 12+ yrs; IKO Industries + WestRock experience; clause-mapped findings; failed-audit cost) are used.

## Not included (intentional, flagged for follow-up)
- **Blog** (`pages/blog/index.js` + 13 post bodies, ~40k words) — still AI-forward; two excerpts say "AI-powered" and post #11 is titled "Traditional ISO Consultants vs. AI." Realigning is a separate large effort.
- Logo filename still `iso-9001-ai-powered-compliance-auditsready-logo.png` (cosmetic).
- `public/sitemap.xml` tone still generalist.

## Verification
`next build` compiles successfully. No deploy performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)